### PR TITLE
Enable export for EC2-hosted environments

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -14,7 +14,7 @@ github.com/google/go-querystring	git	9235644dd9e52eeae6fa48efd539fdc351a0af53	20
 github.com/gorilla/schema	git	08023a0215e7fc27a9aecd8b8c50913c40019478	2016-04-26T23:15:12Z
 github.com/gorilla/websocket	git	13e4d0621caa4d77fd9aa470ef6d7ab63d1a5e41	2015-09-23T22:29:30Z
 github.com/gosuri/uitable	git	36ee7e946282a3fb1cfecd476ddc9b35d8847e42	2016-04-04T20:39:58Z
-github.com/joyent/gocommon	git	ade826b8b54e81a779ccb29d358a45ba24b7809c	2016-03-20T19:31:33Z
+github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	b7f8007afb65647543e768d5a71b4dcb26bcfe1f	2016-04-08T17:20:39Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z

--- a/juju-1.25-upgrade/main.go
+++ b/juju-1.25-upgrade/main.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/juju/1.25-upgrade/commands"
 	"github.com/juju/1.25-upgrade/juju1/juju/osenv"
+	// Ensure all 1.25 providers are registered for export.
+	_ "github.com/juju/1.25-upgrade/juju1/provider/all"
 )
 
 var logger = loggo.GetLogger("upgrader")

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -189,7 +189,16 @@ func (e *exporter) splitEnvironConfig() (map[string]interface{}, description.Clo
 
 	switch cloudType {
 	case "ec2":
-		return nil, creds, region, errors.Errorf("ec2 not yet done")
+		creds.AuthType = "access-key"
+		creds.Attributes = map[string]string{
+			"access-key": modelConfig["access-key"].(string),
+			"secret-key": modelConfig["secret-key"].(string),
+		}
+		region = modelConfig["region"].(string)
+		delete(modelConfig, "region")
+		delete(modelConfig, "access-key")
+		delete(modelConfig, "secret-key")
+
 	case "maas":
 		creds.AuthType = "oauth1"
 		creds.Attributes = map[string]string{


### PR DESCRIPTION
Import all of the providers so they're registered correctly and fill in the ec2 part of the export. Also required changing the joyent dependencies to match Juju 1.25 - the more recent one doesn't accept a loggo.Logger. 