### PR TITLE
Get verify-source working with updated juju/description

### DIFF
--- a/commands/remote.go
+++ b/commands/remote.go
@@ -44,7 +44,7 @@ func localMD5Sum(plugin string) (string, error) {
 }
 
 func updateRemotePlugin(plugin, address string) error {
-	scp := exec.Command("scp", plugin, fmt.Sprintf("ubuntu@%s:~", address))
+	scp := exec.Command("scp", "-C", plugin, fmt.Sprintf("ubuntu@%s:~", address))
 	copyResult, err := scp.CombinedOutput()
 	if err != nil {
 		return errors.Annotate(err, "copying command to environment")

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -453,6 +453,19 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 	}
 	exMachine.SetInstance(e.newCloudInstanceArgs(instData))
 
+	// There're no status records for instances in 1.25 - fake them.
+	instance := exMachine.Instance()
+	status, err := machine.InstanceStatus()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	instStatusArgs := description.StatusArgs{
+		Value:   status,
+		Updated: time.Now(),
+	}
+	instance.SetStatus(instStatusArgs)
+	instance.SetStatusHistory([]description.StatusArgs{instStatusArgs})
+
 	// We don't rely on devices being there. If they aren't, we get an empty slice,
 	// which is fine to iterate over with range.
 	for _, device := range blockDevices[machine.doc.Id] {

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -90,6 +90,9 @@ func (st *State) Export() (description.Model, error) {
 		return nil, errors.Trace(err)
 	}
 	export.model.SetConstraints(constraintsArgs)
+	if err := export.modelStatus(); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := export.modelUsers(); err != nil {
 		return nil, errors.Trace(err)
@@ -284,6 +287,17 @@ func (e *exporter) readBlocks() (map[string]string, error) {
 		result[doc.Type.MigrationValue()] = doc.Message
 	}
 	return result, nil
+}
+
+func (e *exporter) modelStatus() error {
+	// No model status in 1.25 - fake an entry, since it's required in 2.2.2.
+	args := description.StatusArgs{
+		Value:   "available",
+		Updated: time.Now(),
+	}
+	e.model.SetStatus(args)
+	e.model.SetStatusHistory([]description.StatusArgs{args})
+	return nil
 }
 
 func (e *exporter) modelUsers() error {


### PR DESCRIPTION
This version of juju/description does more validation of the exported model - it looks for instance and model status records, which needed to be faked from the 1.25 data model.

Includes a drive-by to turn on compression when copying the plugin to the remote server.