### PR TITLE
Extend upgrade-agents and add rollback-agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ godeps: $(GOPATH)/bin/godeps
 	$(GOPATH)/bin/godeps -u dependencies.tsv
 
 install: godeps
+	go generate ./commands
 	go install -v ./juju-1.25-upgrade 
 
 .PHONY: default godeps install

--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -23,7 +23,7 @@ AGENTS_DIR = path.join(BASE_DIR, 'agents')
 
 UPGRADE_DIR, SCRIPT = path.split(__file__)
 
-HOOK_TOOLS = """
+HOOK_TOOLS = """\
 action-fail
 action-get
 action-set
@@ -113,6 +113,8 @@ def rollback():
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(backup_path, agent_conf)
 
+    added_tools = path.join(TOOLS_DIR, path.basename(find_new_tools()))
+    shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
 
 if __name__ == "__main__":

--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -1,0 +1,123 @@
+# Copyright 2017 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+"""
+Upgrades the local agents to use the new tools binary in a directory
+beside this script. Keeps all changed files in
+/var/lib/juju/1.25-upgrade-rollback so that they can be restored if
+needed.
+"""
+import os
+from os import path
+import shutil
+import sys
+
+# Config passed in from the upgrade tool.
+FILE_FORMAT = '2.0'
+CA_CERT = """{{.ControllerInfo.CACert}}"""
+CONTROLLER_TAG = '{{.ControllerTag}}'
+
+BASE_DIR = '/var/lib/juju'
+ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
+TOOLS_DIR = path.join(BASE_DIR, 'tools')
+AGENTS_DIR = path.join(BASE_DIR, 'agents')
+
+UPGRADE_DIR, SCRIPT = path.split(__file__)
+
+HOOK_TOOLS = """
+action-fail
+action-get
+action-set
+add-metric
+application-version-set
+close-port
+config-get
+is-leader
+juju-log
+juju-reboot
+leader-get
+leader-set
+network-get
+opened-ports
+open-port
+payload-register
+payload-status-set
+payload-unregister
+relation-get
+relation-ids
+relation-list
+relation-set
+resource-get
+status-get
+status-set
+storage-add
+storage-get
+storage-list
+unit-get
+""".splitlines()
+
+def all_agents():
+    return os.listdir(AGENTS_DIR)
+
+def save_rollback_info():
+    os.mkdir(ROLLBACK_DIR)
+    for agent in all_agents():
+        tools_link = path.join(TOOLS_DIR, agent)
+        target = os.readlink(tools_link)
+        os.symlink(target, path.join(ROLLBACK_DIR, agent))
+
+        agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
+        backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
+        shutil.copy(agent_conf, backup_path)
+
+def find_new_tools():
+    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.isdir(path.join(UPGRADE_DIR, name))]
+    assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
+    return path.join(UPGRADE_DIR, dirs[0])
+
+def install_tools():
+    new_tools_path = find_new_tools()
+    dest_path = path.join(TOOLS_DIR, path.basename(new_tools_path))
+    shutil.copytree(new_tools_path, dest_path)
+    # Make all the hook tools link to jujud.
+    make_links(dest_path, HOOK_TOOLS, path.join(dest_path, 'jujud'))
+    # Make all of the agent tools dirs link to the new version.
+    make_links(TOOLS_DIR, all_agents(), dest_path)
+
+def make_links(in_dir, names, target):
+    for name in names:
+        link_path = path.join(in_dir, name)
+        if path.exists(link_path):
+            os.unlink(link_path)
+        os.symlink(target, link_path)
+
+def update_configs():
+    pass
+
+def main():
+    assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'
+    save_rollback_info()
+    install_tools()
+    update_configs()
+
+def rollback():
+    assert path.exists(ROLLBACK_DIR), 'no rollback information found'
+    for agent in all_agents():
+        link_path = path.join(ROLLBACK_DIR, agent)
+        target = os.readlink(link_path)
+        dest = path.join(TOOLS_DIR, agent)
+        if path.exists(dest):
+            os.unlink(dest)
+        os.symlink(target, dest)
+
+        agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
+        backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
+        shutil.copy(backup_path, agent_conf)
+
+    shutil.rmtree(ROLLBACK_DIR)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "rollback":
+        rollback()
+    else:
+        main()
+    sys.exit(0)

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -1,0 +1,131 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+// Generated code - do not edit.
+
+const agentUpgradeScript = `# Copyright 2017 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+"""
+Upgrades the local agents to use the new tools binary in a directory
+beside this script. Keeps all changed files in
+/var/lib/juju/1.25-upgrade-rollback so that they can be restored if
+needed.
+"""
+import os
+from os import path
+import shutil
+import sys
+
+# Config passed in from the upgrade tool.
+FILE_FORMAT = '2.0'
+CA_CERT = """{{.ControllerInfo.CACert}}"""
+CONTROLLER_TAG = '{{.ControllerTag}}'
+
+BASE_DIR = '/var/lib/juju'
+ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
+TOOLS_DIR = path.join(BASE_DIR, 'tools')
+AGENTS_DIR = path.join(BASE_DIR, 'agents')
+
+UPGRADE_DIR, SCRIPT = path.split(__file__)
+
+HOOK_TOOLS = """
+action-fail
+action-get
+action-set
+add-metric
+application-version-set
+close-port
+config-get
+is-leader
+juju-log
+juju-reboot
+leader-get
+leader-set
+network-get
+opened-ports
+open-port
+payload-register
+payload-status-set
+payload-unregister
+relation-get
+relation-ids
+relation-list
+relation-set
+resource-get
+status-get
+status-set
+storage-add
+storage-get
+storage-list
+unit-get
+""".splitlines()
+
+def all_agents():
+    return os.listdir(AGENTS_DIR)
+
+def save_rollback_info():
+    os.mkdir(ROLLBACK_DIR)
+    for agent in all_agents():
+        tools_link = path.join(TOOLS_DIR, agent)
+        target = os.readlink(tools_link)
+        os.symlink(target, path.join(ROLLBACK_DIR, agent))
+
+        agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
+        backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
+        shutil.copy(agent_conf, backup_path)
+
+def find_new_tools():
+    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.isdir(path.join(UPGRADE_DIR, name))]
+    assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
+    return path.join(UPGRADE_DIR, dirs[0])
+
+def install_tools():
+    new_tools_path = find_new_tools()
+    dest_path = path.join(TOOLS_DIR, path.basename(new_tools_path))
+    shutil.copytree(new_tools_path, dest_path)
+    # Make all the hook tools link to jujud.
+    make_links(dest_path, HOOK_TOOLS, path.join(dest_path, 'jujud'))
+    # Make all of the agent tools dirs link to the new version.
+    make_links(TOOLS_DIR, all_agents(), dest_path)
+
+def make_links(in_dir, names, target):
+    for name in names:
+        link_path = path.join(in_dir, name)
+        if path.exists(link_path):
+            os.unlink(link_path)
+        os.symlink(target, link_path)
+
+def update_configs():
+    pass
+
+def main():
+    assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'
+    save_rollback_info()
+    install_tools()
+    update_configs()
+
+def rollback():
+    assert path.exists(ROLLBACK_DIR), 'no rollback information found'
+    for agent in all_agents():
+        link_path = path.join(ROLLBACK_DIR, agent)
+        target = os.readlink(link_path)
+        dest = path.join(TOOLS_DIR, agent)
+        if path.exists(dest):
+            os.unlink(dest)
+        os.symlink(target, dest)
+
+        agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
+        backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
+        shutil.copy(backup_path, agent_conf)
+
+    shutil.rmtree(ROLLBACK_DIR)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "rollback":
+        rollback()
+    else:
+        main()
+    sys.exit(0)
+`

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -30,7 +30,7 @@ AGENTS_DIR = path.join(BASE_DIR, 'agents')
 
 UPGRADE_DIR, SCRIPT = path.split(__file__)
 
-HOOK_TOOLS = """
+HOOK_TOOLS = """\
 action-fail
 action-get
 action-set
@@ -120,6 +120,8 @@ def rollback():
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(backup_path, agent_conf)
 
+    added_tools = path.join(TOOLS_DIR, path.basename(find_new_tools()))
+    shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
 
 if __name__ == "__main__":

--- a/commands/exec.go
+++ b/commands/exec.go
@@ -56,18 +56,23 @@ func withStderr(w io.Writer) execOption {
 	}
 }
 
+func defaultSSHOptions() ssh.Options {
+	var options ssh.Options
+	// Strict host key checking must be disabled because Juju 1.25 did not
+	// populate SSH host keys.
+	options.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
+	options.SetKnownHostsFile(os.DevNull)
+	return options
+}
+
 // runViaSSH runs script in the remote machine with address addr.
 func runViaSSH(addr, script string, opts ...execOption) (int, error) {
 	// This is taken from cmd/juju/ssh.go there is no other clear way to set user
 	userAddr := "ubuntu@" + addr
 
-	var options execOptions
+	options := execOptions{Options: defaultSSHOptions()}
 	options.stdout = os.Stdout
 	options.stderr = os.Stderr
-	// Strict host key checking must be disabled because Juju 1.25 did not
-	// populate SSH host keys.
-	options.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
-	options.SetKnownHostsFile(os.DevNull)
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/commands/main.go
+++ b/commands/main.go
@@ -51,4 +51,6 @@ func registerCommands(super *cmd.SuperCommand) {
 	super.Register(newUpgradeAgentsImplCommand())
 	super.Register(newBackupLXCCommand())
 	super.Register(newBackupLXCImplCommand())
+	super.Register(newRollbackAgentsCommand())
+	super.Register(newRollbackAgentsImplCommand())
 }

--- a/commands/rollbackagents.go
+++ b/commands/rollbackagents.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+)
+
+var rollbackAgentsDoc = `
+
+The rollback-agents command rolls back the actions of a previous
+upgrade-agents command on the machines in a Juju 1.25 environment.
+
+It removes the installed Juju 2 tools, sets symlinks back to the
+previous version and undoes the changes to agent configurations.
+
+`
+
+func newRollbackAgentsCommand() cmd.Command {
+	command := &rollbackAgentsCommand{}
+	command.remoteCommand = "rollback-agents-impl"
+	return wrap(command)
+}
+
+type rollbackAgentsCommand struct {
+	baseClientCommand
+}
+
+func (c *rollbackAgentsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "rollback-agents",
+		Args:    "<environment name>",
+		Purpose: "rollback a previous upgrade-agents in the specified environment",
+		Doc:     rollbackAgentsDoc,
+	}
+}
+
+func (c *rollbackAgentsCommand) Init(args []string) error {
+	args, err := c.baseClientCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return cmd.CheckEmpty(args)
+}
+
+var rollbackAgentsImplDoc = `
+
+rollback-agents-impl must be executed on an API server machine of a 1.25
+environment.
+
+The command will roll back the effects of a previous upgrade-agents
+command.
+
+`
+
+func newRollbackAgentsImplCommand() cmd.Command {
+	return &rollbackAgentsImplCommand{}
+}
+
+type rollbackAgentsImplCommand struct {
+	baseRemoteCommand
+}
+
+func (c *rollbackAgentsImplCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "rollback-agents-impl",
+		Purpose: "controller aspect of rollback-agents",
+		Doc:     rollbackAgentsImplDoc,
+	}
+}
+
+func (c *rollbackAgentsImplCommand) Run(ctx *cmd.Context) error {
+	st, err := c.getState(ctx)
+	if err != nil {
+		return errors.Annotate(err, "getting state")
+	}
+	defer st.Close()
+
+	machines, err := getMachines(st)
+	if err != nil {
+		return errors.Annotate(err, "unable to get addresses for machines")
+	}
+
+	results := parallelCall(machines, "python3 ~/1.25-agent-upgrade/agent-upgrade.py rollback")
+
+	var badMachines []string
+	for _, res := range results {
+		if res.Error != nil {
+			logger.Errorf("failed to rollback on machine %s: %s", res.MachineID, res.Error)
+			badMachines = append(badMachines, res.MachineID)
+		}
+	}
+
+	if len(badMachines) > 0 {
+		plural := "s"
+		if len(badMachines) == 1 {
+			plural = ""
+		}
+		return errors.Errorf("rollback failed on machine%s %s",
+			plural, strings.Join(badMachines, ", "))
+	}
+
+	return nil
+}

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -232,7 +232,7 @@ func (c *upgradeAgentsImplCommand) pushToolsToMachine(ctx *cmd.Context, ver vers
 		return &cmd.RcPassthroughError{Code: rc}
 	}
 	toolsPath := path.Join(toolsDir, fmt.Sprintf("%s-%s", ver, seriesArch(machine)))
-	var options ssh.Options
+	options := defaultSSHOptions()
 	options.SetIdentities(systemIdentity)
 	logger.Debugf("copying upgrade script and %s to machine %s", toolsPath, machine.ID)
 	args := []string{"-r", toolsPath, scriptPath, fmt.Sprintf("ubuntu@%s:~/1.25-agent-upgrade/", machine.Address)}

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -31,14 +31,14 @@ import (
 
 //go:generate go run ../juju2/generate/filetoconst/filetoconst.go agentUpgradeScript agent-upgrade.py agentupgrade_script.go 2017 commands
 
-var upgradeAgentsDoc = ` 
+var upgradeAgentsDoc = `
 
 The purpose of the upgrade-agents command is to upgrade the agents on the 1.25
 environment to the version used by the controller.
 
 This command updates the tools symlinks for the agents, and updates their
 agent config files to specify the correct version, along with the CA Cert and
-addersses of the controller.
+addresses of the controller.
 
 `
 
@@ -123,8 +123,6 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
-
-	_ = machines
 
 	conn, err := c.getControllerConnection()
 	if err != nil {


### PR DESCRIPTION
The `upgrade-agents` command now pushes the binaries to all machines in the environment, and pushes an `agent-upgrade` Python script to install the tools and update agent tools links (and it will update agent configs, although that isn't implemented yet). 

The agent-upgrade script also saves all of the agent tools links and config files for rollback, and has a rollback mode that replaces them and removes the installed tools. This is run by the `rollback-agents` command.

