### PR TITLE
Handle containers as SSH targets

### DIFF
--- a/commands/startagents.go
+++ b/commands/startagents.go
@@ -81,11 +81,11 @@ func (c *startAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
 
-	serviceCommand(ctx, machines, "start")
+	if err := serviceCommand(ctx, machines, "start"); err != nil {
+		return errors.Annotate(err, "starting agents")
+	}
 
 	// The information is then gathered and parsed and formatted here before
 	// the data is passed back to the caller.
-	serviceStatus(ctx, machines)
-
-	return nil
+	return printServiceStatus(ctx, machines)
 }

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -169,7 +169,11 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	results := parallelCall(machines, "python3 ~/1.25-agent-upgrade/agent-upgrade.py")
+	targets := flatMachineExecTargets(machines...)
+	results, err := parallelExec(targets, "python3 ~/1.25-agent-upgrade/agent-upgrade.py")
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	logger.Debugf("results: %#v", results)
 


### PR DESCRIPTION
Proxy SSH connections to containers
through their hosts.

Refactor parallelCall, renaming it
to parallelExec, and dropping the
irrelevant details of DistResult.
It now takes a list of targets
(machine/host addresses), and a
command to execute on each. The
callers mix the results with
machine details as needed.

Also, stop swallowing errors when
making "service" command calls. We
are still just logging the output of
failed "service" command executions,
but we no longer swallow the outright
SSH transport failures.