### PR TITLE
Start LXD containers up after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Check the status of all the agents.
   juju 1.25-upgrade stop-agents <envname>
 
 
+## Stop and backup the LXC containers in the source environment.
+## Migrate LXC containers in the source environment to LXD.
+### Start LXD containers, stop agents
+
+
 ## Import the environment into the controller
 
   juju 1.25-upgrade import <envname> <controller>

--- a/commands/service.go
+++ b/commands/service.go
@@ -132,7 +132,6 @@ done
 				prefix: fmt.Sprintf("(%s:stdout) ", machines[i].ID),
 			}
 			io.WriteString(w, result.Stdout)
-			w.Flush()
 		}
 		if strings.TrimSpace(result.Stderr) != "" {
 			w := &prefixWriter{
@@ -140,7 +139,6 @@ done
 				prefix: fmt.Sprintf("(%s:stderr) ", machines[i].ID),
 			}
 			io.WriteString(w, result.Stderr)
-			w.Flush()
 		}
 	}
 	if len(failed) == 0 {

--- a/commands/service.go
+++ b/commands/service.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/juju/cmd/output"
+)
+
+func printServiceStatus(ctx *cmd.Context, machines []FlatMachine) error {
+	serviceStatusOutput, err := agentServiceCommand(ctx, machines, "status")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	values := parseStatus(machines, serviceStatusOutput)
+	writer := output.TabWriter(ctx.Stdout)
+	wrapper := output.Wrapper{writer}
+	wrapper.Println("AGENT", "STATUS", "VERSION")
+	for _, v := range values {
+		wrapper.Println(v.agent, v.status, v.version)
+	}
+	writer.Flush()
+	return nil
+}
+
+type statusResult struct {
+	agent   string
+	status  string
+	version string
+}
+
+func parseStatus(machines []FlatMachine, serviceStatusOutput []string) []statusResult {
+	var results []statusResult
+
+	for i, stdout := range serviceStatusOutput {
+		machine := machines[i]
+		agents := strings.Split(stdout, "-- end-of-agent --\n")
+		for _, agent := range agents[:len(agents)-1] {
+			var result statusResult
+			parts := strings.SplitN(agent, "\n", 3)
+			result.agent = parts[0]
+			lsParts := strings.Split(parts[1], " ")
+			toolsPath := lsParts[len(lsParts)-1]
+			result.version = path.Base(toolsPath)
+			switch machine.Series {
+			case "trusty":
+				result.status = upstartStatus(parts[2])
+			default:
+				result.status = systemdStatus(parts[2])
+			}
+			logger.Debugf("%#v", result)
+			results = append(results, result)
+		}
+	}
+
+	sort.Sort(statusResults(results))
+	return results
+}
+
+type statusResults []statusResult
+
+func (r statusResults) Len() int           { return len(r) }
+func (r statusResults) Less(i, j int) bool { return r[i].agent < r[j].agent }
+func (r statusResults) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+
+var upstartRegexp = regexp.MustCompile(`jujud-[\w-]+ ([\w/]+)`)
+
+func upstartStatus(output string) string {
+	matches := upstartRegexp.FindStringSubmatch(output)
+	switch len(matches) {
+	case 2:
+		return matches[1]
+	default:
+		logger.Warningf("unable to determine status from:\n%s", output)
+		return "unknown"
+	}
+}
+
+var systemdRegexp = regexp.MustCompile(`Active: (\w+ \(\w+\))`)
+
+func systemdStatus(output string) string {
+	matches := systemdRegexp.FindStringSubmatch(output)
+	switch len(matches) {
+	case 2:
+		return matches[1]
+	default:
+		logger.Warningf("unable to determine status from:\n%s", output)
+		return "unknown"
+	}
+}
+
+// agentServiceCommand runs the given "service" subcommand for every Juju agent
+// on the specified machines, and returns the stdout for each. If any of the
+// commands fail, this function call will return an error, and anything written
+// to stderr will be logged, prefixed by the name of the machine on which the
+// command failed.
+func agentServiceCommand(ctx *cmd.Context, machines []FlatMachine, command string) ([]string, error) {
+	script := fmt.Sprintf(`
+set -xu
+cd /var/lib/juju/agents
+for agent in *
+do
+	echo $agent
+	ls -al /var/lib/juju/tools/$agent
+	sudo service jujud-$agent %s
+	echo "-- end-of-agent --"
+done
+	`, command)
+
+	targets := flatMachineExecTargets(machines...)
+	results, err := parallelExec(targets, script)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var failed []string
+	stdout := make([]string, len(results))
+	for i, result := range results {
+		if result.Code == 0 {
+			stdout[i] = result.Stdout
+			continue
+		}
+		failed = append(failed, machines[i].ID)
+		if strings.TrimSpace(result.Stdout) != "" {
+			w := &prefixWriter{
+				Writer: ctx.GetStderr(),
+				prefix: fmt.Sprintf("(%s:stdout) ", machines[i].ID),
+			}
+			io.WriteString(w, result.Stdout)
+			w.Flush()
+		}
+		if strings.TrimSpace(result.Stderr) != "" {
+			w := &prefixWriter{
+				Writer: ctx.GetStderr(),
+				prefix: fmt.Sprintf("(%s:stderr) ", machines[i].ID),
+			}
+			io.WriteString(w, result.Stderr)
+			w.Flush()
+		}
+	}
+	if len(failed) == 0 {
+		return stdout, nil
+	}
+	plural := ""
+	if len(failed) > 1 {
+		plural = "s"
+	}
+	return nil, errors.Errorf("service %s command failed for machine%s %q", command, plural, failed)
+}

--- a/commands/startagents.go
+++ b/commands/startagents.go
@@ -81,7 +81,7 @@ func (c *startAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
 
-	if err := serviceCommand(ctx, machines, "start"); err != nil {
+	if _, err := agentServiceCommand(ctx, machines, "start"); err != nil {
 		return errors.Annotate(err, "starting agents")
 	}
 

--- a/commands/stopagents.go
+++ b/commands/stopagents.go
@@ -81,25 +81,11 @@ func (c *stopAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
 
-	if err := serviceCommand(ctx, machines, "stop"); err != nil {
+	if _, err := agentServiceCommand(ctx, machines, "stop"); err != nil {
 		return errors.Annotate(err, "stopping agents")
 	}
 
 	// The information is then gathered and parsed and formatted here before
 	// the data is passed back to the caller.
 	return printServiceStatus(ctx, machines)
-}
-
-func serviceCommand(ctx *cmd.Context, machines []FlatMachine, verb string) error {
-	results, err := serviceCall(machines, verb)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for i, r := range results {
-		m := machines[i]
-		if r.Code != 0 {
-			logger.Warningf("machine: %s rc: %d\nstdout:%s\nstderr:%s", m.ID, r.Code, r.Stdout, r.Stderr)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
After migrating LXC containers to LXD,
start the LXD containers up so that
other commands can SSH into them to
run the remaining parts of the upgrade,
such as upgrade-agents. After starting
the LXD containers, the Juju agents are
stopped.

The "serviceCall" and "serviceCommand"
functions are consolidated into a new
function, agentServiceCommand. This
function will return an error if any
of the executions exit with a non-zero
code. Failed executions will have their
output written to stderr, prefixed with
the machine ID.