### PR TITLE
lxc-to-lxd: ignore IPv4/IPv6 configuration

### DIFF
--- a/commands/lxc-to-lxd
+++ b/commands/lxc-to-lxd
@@ -338,14 +338,17 @@ def convert_container(lxd_socket, container_name, args):
         # Get everything else
         dev = container.network[i]
 
+        # NOTE(axw) we ignore IP configuration, because
+        # it's configured inside the container anyway.
+        #
         # Validate configuration
-        if dev.ipv4 or dev.ipv4_gateway:
-            print("IPv4 network configuration isn't supported, skipping...")
-            return False
-
-        if dev.ipv6 or dev.ipv6_gateway:
-            print("IPv6 network configuration isn't supported, skipping...")
-            return False
+        #if dev.ipv4 or dev.ipv4_gateway:
+        #    print("IPv4 network configuration isn't supported, skipping...")
+        #    return False
+        #
+        #if dev.ipv6 or dev.ipv6_gateway:
+        #    print("IPv6 network configuration isn't supported, skipping...")
+        #    return False
 
         if dev.script_up or dev.script_down:
             print("Network config scripts aren't supported, skipping...")

--- a/commands/lxc2lxd_script.go
+++ b/commands/lxc2lxd_script.go
@@ -345,14 +345,17 @@ def convert_container(lxd_socket, container_name, args):
         # Get everything else
         dev = container.network[i]
 
+        # NOTE(axw) we ignore IP configuration, because
+        # it's configured inside the container anyway.
+        #
         # Validate configuration
-        if dev.ipv4 or dev.ipv4_gateway:
-            print("IPv4 network configuration isn't supported, skipping...")
-            return False
-
-        if dev.ipv6 or dev.ipv6_gateway:
-            print("IPv6 network configuration isn't supported, skipping...")
-            return False
+        #if dev.ipv4 or dev.ipv4_gateway:
+        #    print("IPv4 network configuration isn't supported, skipping...")
+        #    return False
+        #
+        #if dev.ipv6 or dev.ipv6_gateway:
+        #    print("IPv6 network configuration isn't supported, skipping...")
+        #    return False
 
         if dev.script_up or dev.script_down:
             print("Network config scripts aren't supported, skipping...")


### PR DESCRIPTION
We can safely ignore the ipv4/ipv6 container
config attributes in LXC, as the same config
is applied to /etc/network/interfaces. This
is the supported mechanism in LXD, and the
LXC config is redundant.