### PR TITLE
verify-source: add MAAS link-layer devices/IPs

### DIFF
--- a/commands/verifysource.go
+++ b/commands/verifysource.go
@@ -4,8 +4,16 @@
 package commands
 
 import (
+	"net"
 	"strings"
 
+	"github.com/juju/1.25-upgrade/juju1/state"
+	"github.com/juju/1.25-upgrade/juju2/apiserver/common/networkingcommon"
+	"github.com/juju/1.25-upgrade/juju2/cloud"
+	"github.com/juju/1.25-upgrade/juju2/environs"
+	"github.com/juju/1.25-upgrade/juju2/environs/config"
+	"github.com/juju/1.25-upgrade/juju2/instance"
+	_ "github.com/juju/1.25-upgrade/juju2/provider/maas"
 	"github.com/juju/cmd"
 	"github.com/juju/description"
 	"github.com/juju/errors"
@@ -101,9 +109,25 @@ func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "dry-running LXC migration")
 	}
 
+	return errors.Annotate(exportModel(ctx, st), "exporting model")
+}
+
+func exportModel(ctx *cmd.Context, st *state.State) error {
 	model, err := st.Export()
 	if err != nil {
 		return errors.Annotate(err, "exporting model representation")
+	}
+
+	if envCfg, err := st.EnvironConfig(); err != nil {
+		return errors.Trace(err)
+	} else if envCfg.Type() == "maas" {
+		// Juju 1.25 doesn't have complete link-layer device definitions
+		// (it has network interfaces, but they lack some of the details)
+		// or IP addresses. Query MAAS for those using the Juju 2.x code,
+		// and fill in the blanks.
+		if err := addMAASNetworkEntities(model, st); err != nil {
+			return errors.Annotate(err, "adding MAAS network entities")
+		}
 	}
 
 	bytes, err := description.Serialize(model)
@@ -114,6 +138,89 @@ func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
 	_, err = ctx.GetStdout().Write(bytes)
 	if err != nil {
 		return errors.Annotate(err, "writing model representation")
+	}
+
+	return nil
+}
+
+// addMAASNetworkEntities adds link-layer devices and IP addresses to
+// the model description. These entities are not modeled by Juju 1.25,
+// so we take the model from 1.25 and augment it by using the Juju 2.x
+// MAAS provider code.
+func addMAASNetworkEntities(model description.Model, st *state.State) error {
+	envCfg, err := st.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	attrs := envCfg.AllAttrs()
+	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+		"maas-oauth": attrs["maas-oauth"].(string),
+	})
+	cloudSpec := environs.CloudSpec{
+		Type:       "maas",
+		Name:       model.Cloud(),
+		Region:     model.CloudRegion(),
+		Endpoint:   attrs["maas-server"].(string),
+		Credential: &cred,
+	}
+
+	modelCfg, err := config.New(config.NoDefaults, model.Config())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	env, err := environs.New(environs.OpenParams{cloudSpec, modelCfg})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	netenv := env.(environs.Networking)
+
+	// Add link-layer devices and IP addresses.
+	for _, machine := range model.Machines() {
+		inst := machine.Instance()
+		if inst == nil {
+			continue
+		}
+		instanceId := inst.InstanceId()
+		if instanceId == "" {
+			continue
+		}
+		interfaces, err := netenv.NetworkInterfaces(instance.Id(instanceId))
+		if err != nil {
+			return errors.Annotatef(err, "getting network interfaces for %q", instanceId)
+		}
+
+		networkConfig := networkingcommon.NetworkConfigFromInterfaceInfo(interfaces)
+		devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(networkConfig)
+		for _, d := range devicesArgs {
+			model.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
+				Name:        d.Name,
+				MTU:         d.MTU,
+				ProviderID:  string(d.ProviderID),
+				MachineID:   machine.Id(),
+				Type:        string(d.Type),
+				MACAddress:  d.MACAddress,
+				IsAutoStart: d.IsAutoStart,
+				IsUp:        d.IsUp,
+				ParentName:  d.ParentName,
+			})
+		}
+		for _, d := range devicesAddrs {
+			ip, ipNet, err := net.ParseCIDR(d.CIDRAddress)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			model.AddIPAddress(description.IPAddressArgs{
+				ProviderID:       string(d.ProviderID),
+				DeviceName:       d.DeviceName,
+				MachineID:        machine.Id(),
+				SubnetCIDR:       ipNet.String(),
+				ConfigMethod:     string(d.ConfigMethod),
+				Value:            ip.String(),
+				DNSServers:       d.DNSServers,
+				DNSSearchDomains: d.DNSSearchDomains,
+				GatewayAddress:   d.GatewayAddress,
+			})
+		}
 	}
 
 	return nil

--- a/juju2/apiserver/metricsender/metricsender.go
+++ b/juju2/apiserver/metricsender/metricsender.go
@@ -28,31 +28,37 @@ var (
 )
 
 func handleModelResponse(st ModelBackend, modelUUID string, modelResp wireformat.EnvResponse) int {
-	err := st.SetMetricBatchesSent(modelResp.AcknowledgedBatches)
-	if err != nil {
-		logger.Errorf("failed to set sent on metrics %v", err)
-	}
-	for unitName, status := range modelResp.UnitStatuses {
-		unit, err := st.Unit(unitName)
+	// NOTE(axw) the code below has been commented out because it does
+	// not build against the dependencies we require for the juju1 tree.
+	// This code is unused by the migration commands.
+	/*
+		err := st.SetMetricBatchesSent(modelResp.AcknowledgedBatches)
 		if err != nil {
-			logger.Errorf("failed to retrieve unit %q: %v", unitName, err)
-			continue
+			logger.Errorf("failed to set sent on metrics %v", err)
 		}
-		err = unit.SetMeterStatus(status.Status, status.Info)
-		if err != nil {
-			logger.Errorf("failed to set unit %q meter status to %v: %v", unitName, status, err)
+		for unitName, status := range modelResp.UnitStatuses {
+			unit, err := st.Unit(unitName)
+			if err != nil {
+				logger.Errorf("failed to retrieve unit %q: %v", unitName, err)
+				continue
+			}
+			err = unit.SetMeterStatus(status.Status, status.Info)
+			if err != nil {
+				logger.Errorf("failed to set unit %q meter status to %v: %v", unitName, status, err)
+			}
 		}
-	}
-	if modelResp.ModelStatus.Status != "" {
-		err = st.SetModelMeterStatus(
-			modelResp.ModelStatus.Status,
-			modelResp.ModelStatus.Info,
-		)
-		if err != nil {
-			logger.Errorf("failed to set the model meter status: %v", err)
+		if modelResp.ModelStatus.Status != "" {
+			err = st.SetModelMeterStatus(
+				modelResp.ModelStatus.Status,
+				modelResp.ModelStatus.Info,
+			)
+			if err != nil {
+				logger.Errorf("failed to set the model meter status: %v", err)
+			}
 		}
-	}
-	return len(modelResp.AcknowledgedBatches)
+		return len(modelResp.AcknowledgedBatches)
+	*/
+	return 0
 }
 
 func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireformat.Response) int {
@@ -190,13 +196,16 @@ func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
 		}
 	}
 	return &wireformat.MetricBatch{
-		UUID:           mb.UUID(),
-		ModelUUID:      mb.ModelUUID(),
-		UnitName:       mb.Unit(),
-		CharmUrl:       mb.CharmURL(),
-		Created:        mb.Created().UTC(),
-		Metrics:        metrics,
-		Credentials:    mb.Credentials(),
-		SLACredentials: mb.SLACredentials(),
+		UUID:        mb.UUID(),
+		ModelUUID:   mb.ModelUUID(),
+		UnitName:    mb.Unit(),
+		CharmUrl:    mb.CharmURL(),
+		Created:     mb.Created().UTC(),
+		Metrics:     metrics,
+		Credentials: mb.Credentials(),
+		// NOTE(axw) the code below has been commented out because it does
+		// not build against the dependencies we require for the juju1 tree.
+		// This code is unused by the migration commands.
+		//SLACredentials: mb.SLACredentials(),
 	}
 }

--- a/juju2/provider/maas/environ.go
+++ b/juju2/provider/maas/environ.go
@@ -280,12 +280,7 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	switch {
 	case gomaasapi.IsUnsupportedVersionError(err):
 		apiVersion = apiVersion1
-		_, _, includesVersion := gomaasapi.SplitVersionedURL(maasServer)
-		versionURL := maasServer
-		if !includesVersion {
-			versionURL = gomaasapi.AddAPIVersionToURL(maasServer, apiVersion1)
-		}
-		authClient, err := gomaasapi.NewAuthenticatedClient(versionURL, maasOAuth)
+		authClient, err := gomaasapi.NewAuthenticatedClient(maasServer, maasOAuth, apiVersion1)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/juju2/provider/maas/environprovider.go
+++ b/juju2/provider/maas/environprovider.go
@@ -79,24 +79,30 @@ func (p MaasEnvironProvider) CloudSchema() *jsonschema.Schema {
 
 // Ping tests the connection to the cloud, to verify the endpoint is valid.
 func (p MaasEnvironProvider) Ping(endpoint string) error {
-	base, version, includesVersion := gomaasapi.SplitVersionedURL(endpoint)
-	if includesVersion {
-		err := p.checkMaas(base, version)
-		if err == nil {
-			return nil
+	// NOTE(axw) the code below has been commented out because it does
+	// not build against the dependencies we require for the juju1 tree.
+	// This code is unused by the migration commands.
+	/*
+		base, version, includesVersion := gomaasapi.SplitVersionedURL(endpoint)
+		if includesVersion {
+			err := p.checkMaas(base, version)
+			if err == nil {
+				return nil
+			}
+		} else {
+			// No version info in the endpoint - try both in preference order.
+			err := p.checkMaas(endpoint, apiVersion2)
+			if err == nil {
+				return nil
+			}
+			err = p.checkMaas(endpoint, apiVersion1)
+			if err == nil {
+				return nil
+			}
 		}
-	} else {
-		// No version info in the endpoint - try both in preference order.
-		err := p.checkMaas(endpoint, apiVersion2)
-		if err == nil {
-			return nil
-		}
-		err = p.checkMaas(endpoint, apiVersion1)
-		if err == nil {
-			return nil
-		}
-	}
-	return errors.Errorf("No MAAS server running at %s", endpoint)
+		return errors.Errorf("No MAAS server running at %s", endpoint)
+	*/
+	return errors.NotImplementedf("Ping")
 }
 
 func (p MaasEnvironProvider) checkMaas(endpoint, ver string) error {

--- a/juju2/provider/maas/volumes.go
+++ b/juju2/provider/maas/volumes.go
@@ -295,89 +295,95 @@ func (mi *maas2Instance) volumes(
 ) (
 	[]storage.Volume, []storage.VolumeAttachment, error,
 ) {
-	if mi.constraintMatches.Storage == nil {
-		return nil, nil, errors.NotFoundf("constraint storage mapping")
-	}
-
-	var volumes []storage.Volume
-	var attachments []storage.VolumeAttachment
-
-	// Set up a collection of volumes tags which
-	// we specifically asked for when the node was acquired.
-	validVolumes := set.NewStrings()
-	for _, v := range requestedVolumes {
-		validVolumes.Add(v.Id())
-	}
-
-	for label, devices := range mi.constraintMatches.Storage {
-		// We don't explicitly allow the root volume to be specified yet.
-		if label == rootDiskLabel {
-			continue
+	// NOTE(axw) the code below has been commented out because it does
+	// not build against the dependencies we require for the juju1 tree.
+	// This code is unused by the migration commands.
+	/*
+		if mi.constraintMatches.Storage == nil {
+			return nil, nil, errors.NotFoundf("constraint storage mapping")
 		}
 
-		// We only care about the volumes we specifically asked for.
-		if !validVolumes.Contains(label) {
-			continue
+		var volumes []storage.Volume
+		var attachments []storage.VolumeAttachment
+
+		// Set up a collection of volumes tags which
+		// we specifically asked for when the node was acquired.
+		validVolumes := set.NewStrings()
+		for _, v := range requestedVolumes {
+			validVolumes.Add(v.Id())
 		}
 
-		// There should be exactly one block device per label.
-		if len(devices) == 0 {
-			continue
-		} else if len(devices) > 1 {
-			// This should never happen, as we only request one block
-			// device per label. If it does happen, we'll just report
-			// the first block device and log this warning.
-			logger.Warningf(
-				"expected 1 block device for label %s, received %d",
-				label, len(devices),
-			)
-		}
-
-		device := devices[0]
-		volumeTag := names.NewVolumeTag(label)
-		vol := storage.Volume{
-			volumeTag,
-			storage.VolumeInfo{
-				VolumeId:   volumeTag.String(),
-				Size:       uint64(device.Size() / humanize.MiByte),
-				Persistent: false,
-			},
-		}
-		attachment := storage.VolumeAttachment{
-			volumeTag,
-			mTag,
-			storage.VolumeAttachmentInfo{
-				ReadOnly: false,
-			},
-		}
-
-		const devDiskByIdPrefix = "/dev/disk/by-id/"
-		const devPrefix = "/dev/"
-
-		idPath := device.IDPath()
-		if idPath == devPrefix+device.Name() {
-			// On vMAAS (i.e. with virtio), the device name
-			// will be stable, and is what is used to form
-			// id_path.
-			deviceName := idPath[len(devPrefix):]
-			attachment.DeviceName = deviceName
-		} else if strings.HasPrefix(idPath, devDiskByIdPrefix) {
-			const wwnPrefix = "wwn-"
-			id := idPath[len(devDiskByIdPrefix):]
-			if strings.HasPrefix(id, wwnPrefix) {
-				vol.WWN = id[len(wwnPrefix):]
-			} else {
-				vol.HardwareId = id
+		for label, devices := range mi.constraintMatches.Storage {
+			// We don't explicitly allow the root volume to be specified yet.
+			if label == rootDiskLabel {
+				continue
 			}
-		} else {
-			// It's neither /dev/<name> nor /dev/disk/by-id/<hardware-id>,
-			// so set it as the device link and hope for
-			// the best. At worst, the path won't exist
-			// and the storage will remain pending.
-			attachment.DeviceLink = idPath
+
+			// We only care about the volumes we specifically asked for.
+			if !validVolumes.Contains(label) {
+				continue
+			}
+
+			// There should be exactly one block device per label.
+			if len(devices) == 0 {
+				continue
+			} else if len(devices) > 1 {
+				// This should never happen, as we only request one block
+				// device per label. If it does happen, we'll just report
+				// the first block device and log this warning.
+				logger.Warningf(
+					"expected 1 block device for label %s, received %d",
+					label, len(devices),
+				)
+			}
+
+			device := devices[0]
+			volumeTag := names.NewVolumeTag(label)
+			vol := storage.Volume{
+				volumeTag,
+				storage.VolumeInfo{
+					VolumeId:   volumeTag.String(),
+					Size:       uint64(device.Size() / humanize.MiByte),
+					Persistent: false,
+				},
+			}
+			attachment := storage.VolumeAttachment{
+				volumeTag,
+				mTag,
+				storage.VolumeAttachmentInfo{
+					ReadOnly: false,
+				},
+			}
+
+			const devDiskByIdPrefix = "/dev/disk/by-id/"
+			const devPrefix = "/dev/"
+
+			idPath := device.IDPath()
+			if idPath == devPrefix+device.Name() {
+				// On vMAAS (i.e. with virtio), the device name
+				// will be stable, and is what is used to form
+				// id_path.
+				deviceName := idPath[len(devPrefix):]
+				attachment.DeviceName = deviceName
+			} else if strings.HasPrefix(idPath, devDiskByIdPrefix) {
+				const wwnPrefix = "wwn-"
+				id := idPath[len(devDiskByIdPrefix):]
+				if strings.HasPrefix(id, wwnPrefix) {
+					vol.WWN = id[len(wwnPrefix):]
+				} else {
+					vol.HardwareId = id
+				}
+			} else {
+				// It's neither /dev/<name> nor /dev/disk/by-id/<hardware-id>,
+				// so set it as the device link and hope for
+				// the best. At worst, the path won't exist
+				// and the storage will remain pending.
+				attachment.DeviceLink = idPath
+			}
+			volumes = append(volumes, vol)
+			attachments = append(attachments, attachment)
 		}
-		volumes = append(volumes, vol)
-		attachments = append(attachments, attachment)
-	}
-	return volumes, attachments, nil
+		return volumes, attachments, nil
+	*/
+	return nil, nil, errors.NotImplementedf("volumes")
 }


### PR DESCRIPTION
After exporting a MAAS model from 1.25, add
in link-layer devices and IP addresses using the
juju2 tree's MAAS provider code. Provider details
of link-layer devices are otherwise only added to
state by the provisioner, after creating the instance.