### PR TITLE
upgrade-agents: Rewrite agent.conf files

### DIFF
--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -10,11 +10,17 @@ import os
 from os import path
 import shutil
 import sys
+import yaml
+
+FILE_FORMAT = '2.0'
 
 # Config passed in from the upgrade tool.
-FILE_FORMAT = '2.0'
 CA_CERT = """{{.ControllerInfo.CACert}}"""
 CONTROLLER_TAG = '{{.ControllerTag}}'
+VERSION = '{{.Version}}'
+API_ADDRESSES = """{{range .ControllerInfo.Addrs}}{{.}}
+{{end}}""".splitlines()
+API_PASSWORD = '{{.ControllerInfo.Password }}'
 
 BASE_DIR = '/var/lib/juju'
 ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
@@ -55,6 +61,15 @@ storage-list
 unit-get
 """.splitlines()
 
+# Ensure specific text is represented in literal format.
+class Literal(str):
+    pass
+
+def literal_presenter(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+yaml.add_representer(Literal, literal_presenter)
+
+
 def all_agents():
     return os.listdir(AGENTS_DIR)
 
@@ -91,7 +106,47 @@ def make_links(in_dir, names, target):
         os.symlink(target, link_path)
 
 def update_configs():
-    pass
+    for agent in all_agents():
+        data = read_agent_config(agent)
+        if agent.startswith('machine-'):
+            data = update_machine_config(agent, data)
+        else:
+            data = update_unit_config(agent, data)
+        write_agent_config(agent, data)
+
+def config_path(agent):
+    return path.join(AGENTS_DIR, agent, 'agent.conf')
+
+def read_agent_config(agent):
+    with open(config_path(agent)) as f:
+        data = yaml.load(f)
+    return data
+
+def write_agent_config(agent, data):
+    with open(config_path(agent), 'w') as f:
+        f.write('# format %s\n' % FILE_FORMAT)
+        yaml.dump(data, stream=f, default_flow_style=False)
+
+def update_machine_config(agent, data):
+    return update_unit_config(agent, data)
+
+def update_unit_config(agent, data):
+    # Set controller and model.
+    env_tag = data['environment']
+    data['model'] = env_tag.replace('environment', 'model')
+    data['controller'] = CONTROLLER_TAG
+
+    data['upgradedToVersion'] = VERSION
+    data['cacert'] = Literal(CA_CERT)
+
+    data['apipassword'] = API_PASSWORD
+    data['apiaddresses'] = API_ADDRESSES
+
+    # Get rid of unneeded attributes.
+    for name in ('environment', 'stateaddresses', 'statepassword'):
+        del data[name]
+
+    return data
 
 def main():
     assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'

--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -20,7 +20,6 @@ CONTROLLER_TAG = '{{.ControllerTag}}'
 VERSION = '{{.Version}}'
 API_ADDRESSES = """{{range .ControllerInfo.Addrs}}{{.}}
 {{end}}""".splitlines()
-API_PASSWORD = '{{.ControllerInfo.Password }}'
 
 BASE_DIR = '/var/lib/juju'
 ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
@@ -59,6 +58,16 @@ storage-add
 storage-get
 storage-list
 unit-get
+""".splitlines()
+
+OLD_CONTROLLER_KEYS = """\
+stateservercert
+stateserverkey
+caprivatekey
+apiport
+stateport
+sharedsecret
+systemidentity
 """.splitlines()
 
 # Ensure specific text is represented in literal format.
@@ -128,6 +137,12 @@ def write_agent_config(agent, data):
         yaml.dump(data, stream=f, default_flow_style=False)
 
 def update_machine_config(agent, data):
+    # None of these machines will need to manage the environ anymore.
+    data['jobs'] = ['JobHostUnits']
+    # Get rid of API/mongo hosting keys.
+    for name in OLD_CONTROLLER_KEYS:
+        if name in data:
+            del data[name]
     return update_unit_config(agent, data)
 
 def update_unit_config(agent, data):
@@ -139,7 +154,6 @@ def update_unit_config(agent, data):
     data['upgradedToVersion'] = VERSION
     data['cacert'] = Literal(CA_CERT)
 
-    data['apipassword'] = API_PASSWORD
     data['apiaddresses'] = API_ADDRESSES
 
     # Get rid of unneeded attributes.

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -17,11 +17,17 @@ import os
 from os import path
 import shutil
 import sys
+import yaml
+
+FILE_FORMAT = '2.0'
 
 # Config passed in from the upgrade tool.
-FILE_FORMAT = '2.0'
 CA_CERT = """{{.ControllerInfo.CACert}}"""
 CONTROLLER_TAG = '{{.ControllerTag}}'
+VERSION = '{{.Version}}'
+API_ADDRESSES = """{{range .ControllerInfo.Addrs}}{{.}}
+{{end}}""".splitlines()
+API_PASSWORD = '{{.ControllerInfo.Password }}'
 
 BASE_DIR = '/var/lib/juju'
 ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
@@ -62,6 +68,15 @@ storage-list
 unit-get
 """.splitlines()
 
+# Ensure specific text is represented in literal format.
+class Literal(str):
+    pass
+
+def literal_presenter(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+yaml.add_representer(Literal, literal_presenter)
+
+
 def all_agents():
     return os.listdir(AGENTS_DIR)
 
@@ -98,7 +113,47 @@ def make_links(in_dir, names, target):
         os.symlink(target, link_path)
 
 def update_configs():
-    pass
+    for agent in all_agents():
+        data = read_agent_config(agent)
+        if agent.startswith('machine-'):
+            data = update_machine_config(agent, data)
+        else:
+            data = update_unit_config(agent, data)
+        write_agent_config(agent, data)
+
+def config_path(agent):
+    return path.join(AGENTS_DIR, agent, 'agent.conf')
+
+def read_agent_config(agent):
+    with open(config_path(agent)) as f:
+        data = yaml.load(f)
+    return data
+
+def write_agent_config(agent, data):
+    with open(config_path(agent), 'w') as f:
+        f.write('# format %s\n' % FILE_FORMAT)
+        yaml.dump(data, stream=f, default_flow_style=False)
+
+def update_machine_config(agent, data):
+    return update_unit_config(agent, data)
+
+def update_unit_config(agent, data):
+    # Set controller and model.
+    env_tag = data['environment']
+    data['model'] = env_tag.replace('environment', 'model')
+    data['controller'] = CONTROLLER_TAG
+
+    data['upgradedToVersion'] = VERSION
+    data['cacert'] = Literal(CA_CERT)
+
+    data['apipassword'] = API_PASSWORD
+    data['apiaddresses'] = API_ADDRESSES
+
+    # Get rid of unneeded attributes.
+    for name in ('environment', 'stateaddresses', 'statepassword'):
+        del data[name]
+
+    return data
 
 def main():
     assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'

--- a/commands/rollbackagents.go
+++ b/commands/rollbackagents.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -86,25 +85,7 @@ func (c *rollbackAgentsImplCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	var badMachines []string
-	for i, res := range results {
-		if res.Code != 0 {
-			logger.Errorf("failed to rollback on machine %s: exited with %d", machines[i].ID, res.Code)
-			badMachines = append(badMachines, machines[i].ID)
-		}
-	}
-
-	if len(badMachines) > 0 {
-		plural := "s"
-		if len(badMachines) == 1 {
-			plural = ""
-		}
-		return errors.Errorf("rollback failed on machine%s %s",
-			plural, strings.Join(badMachines, ", "))
-	}
-
-	return nil
+	return errors.Trace(reportResults(ctx, "rollback", machines, results))
 }
 
 func (c *rollbackAgentsImplCommand) loadMachines() ([]FlatMachine, error) {

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -181,22 +181,7 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	for i, result := range results {
-		if result.Code != 0 {
-			fmt.Fprintf(
-				ctx.Stdout,
-				"Upgrading agents on machine %s returned %d:\nOutput was:\n%s\n\nError was:\n%s\n",
-				machines[i].ID,
-				result.Code,
-				result.Stdout,
-				result.Stderr,
-			)
-		}
-	}
-	logger.Debugf("results: %#v", results)
-
-	return errors.Errorf("this command not yet finished")
+	return errors.Trace(reportResults(ctx, "upgrade", machines, results))
 }
 
 func (c *upgradeAgentsImplCommand) getTools(ctx *cmd.Context, client *http.Client, ver version.Number, toolsURLPrefix, seriesArch string) error {

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -126,14 +126,6 @@ func (st *State) Export() (description.Model, error) {
 	}
 
 	// <---- migration checked up to here...
-	if err := export.actions(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if err := export.cloudimagemetadata(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	if err := export.model.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Also save of the list of machines in upgrade-agents so that it can be used when rolling back (since we can't guarantee that we can connect to state after upgrading the agents).