### PR TITLE
Add import command

### DIFF
--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -6,10 +6,12 @@ beside this script. Keeps all changed files in
 /var/lib/juju/1.25-upgrade-rollback so that they can be restored if
 needed.
 """
+import json
 import os
 from os import path
 import shutil
 import sys
+import tarfile
 import yaml
 
 FILE_FORMAT = '2.0'
@@ -94,14 +96,29 @@ def save_rollback_info():
         shutil.copy(agent_conf, backup_path)
 
 def find_new_tools():
-    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.isdir(path.join(UPGRADE_DIR, name))]
+    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
     assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
     return path.join(UPGRADE_DIR, dirs[0])
 
+def unpack_tools(source, dest_path):
+    with tarfile.open(name=source, mode='r:gz') as contents:
+        for item in contents:
+            contents.extract(item, path=dest_path)
+            item_path = path.join(dest_path, item.name)
+            shutil.chown(item_path, 'root', 'root')
+
+def write_tool_metadata(version, dest_path):
+    with open(path.join(dest_path, 'downloaded-tools.txt'), 'w') as metadata:
+        json.dump(dict(version=version, url="", size=0), metadata)
+
 def install_tools():
     new_tools_path = find_new_tools()
-    dest_path = path.join(TOOLS_DIR, path.basename(new_tools_path))
-    shutil.copytree(new_tools_path, dest_path)
+    # get 2.2.3-xenial-amd64 from ~/1.25-agent-upgrade/2.2.3-xenial-amd64.tgz
+    tools_base, _ = path.splitext(path.basename(new_tools_path))
+    dest_path = path.join(TOOLS_DIR, tools_base)
+    os.mkdir(dest_path)
+    unpack_tools(new_tools_path, dest_path)
+    write_tool_metadata(tools_base, dest_path)
     # Make all the hook tools link to jujud.
     make_links(dest_path, HOOK_TOOLS, path.join(dest_path, 'jujud'))
     # Make all of the agent tools dirs link to the new version.
@@ -182,7 +199,8 @@ def rollback():
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(backup_path, agent_conf)
 
-    added_tools = path.join(TOOLS_DIR, path.basename(find_new_tools()))
+    tools_base, _ = path.splitext(path.basename(find_new_tools()))
+    added_tools = path.join(TOOLS_DIR, tools_base)
     shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
 

--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -96,9 +96,9 @@ def save_rollback_info():
         shutil.copy(agent_conf, backup_path)
 
 def find_new_tools():
-    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
-    assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
-    return path.join(UPGRADE_DIR, dirs[0])
+    files = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
+    assert len(files) == 1, 'too many tools files found: {}'.format(files)
+    return path.join(UPGRADE_DIR, files[0])
 
 def unpack_tools(source, dest_path):
     with tarfile.open(name=source, mode='r:gz') as contents:

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -13,10 +13,12 @@ beside this script. Keeps all changed files in
 /var/lib/juju/1.25-upgrade-rollback so that they can be restored if
 needed.
 """
+import json
 import os
 from os import path
 import shutil
 import sys
+import tarfile
 import yaml
 
 FILE_FORMAT = '2.0'
@@ -101,14 +103,29 @@ def save_rollback_info():
         shutil.copy(agent_conf, backup_path)
 
 def find_new_tools():
-    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.isdir(path.join(UPGRADE_DIR, name))]
+    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
     assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
     return path.join(UPGRADE_DIR, dirs[0])
 
+def unpack_tools(source, dest_path):
+    with tarfile.open(name=source, mode='r:gz') as contents:
+        for item in contents:
+            contents.extract(item, path=dest_path)
+            item_path = path.join(dest_path, item.name)
+            shutil.chown(item_path, 'root', 'root')
+
+def write_tool_metadata(version, dest_path):
+    with open(path.join(dest_path, 'downloaded-tools.txt'), 'w') as metadata:
+        json.dump(dict(version=version, url="", size=0), metadata)
+
 def install_tools():
     new_tools_path = find_new_tools()
-    dest_path = path.join(TOOLS_DIR, path.basename(new_tools_path))
-    shutil.copytree(new_tools_path, dest_path)
+    # get 2.2.3-xenial-amd64 from ~/1.25-agent-upgrade/2.2.3-xenial-amd64.tgz
+    tools_base, _ = path.splitext(path.basename(new_tools_path))
+    dest_path = path.join(TOOLS_DIR, tools_base)
+    os.mkdir(dest_path)
+    unpack_tools(new_tools_path, dest_path)
+    write_tool_metadata(tools_base, dest_path)
     # Make all the hook tools link to jujud.
     make_links(dest_path, HOOK_TOOLS, path.join(dest_path, 'jujud'))
     # Make all of the agent tools dirs link to the new version.
@@ -189,7 +206,8 @@ def rollback():
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(backup_path, agent_conf)
 
-    added_tools = path.join(TOOLS_DIR, path.basename(find_new_tools()))
+    tools_base, _ = path.splitext(path.basename(find_new_tools()))
+    added_tools = path.join(TOOLS_DIR, tools_base)
     shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
 

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -103,9 +103,9 @@ def save_rollback_info():
         shutil.copy(agent_conf, backup_path)
 
 def find_new_tools():
-    dirs = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
-    assert len(dirs) == 1, 'too many tools dirs found: {}'.format(dirs)
-    return path.join(UPGRADE_DIR, dirs[0])
+    files = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
+    assert len(files) == 1, 'too many tools files found: {}'.format(files)
+    return path.join(UPGRADE_DIR, files[0])
 
 def unpack_tools(source, dest_path):
     with tarfile.open(name=source, mode='r:gz') as contents:

--- a/commands/export.go
+++ b/commands/export.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"net"
+
+	"github.com/juju/description"
+	"github.com/juju/errors"
+
+	"github.com/juju/1.25-upgrade/juju1/state"
+	"github.com/juju/1.25-upgrade/juju2/apiserver/common/networkingcommon"
+	"github.com/juju/1.25-upgrade/juju2/cloud"
+	"github.com/juju/1.25-upgrade/juju2/environs"
+	"github.com/juju/1.25-upgrade/juju2/environs/config"
+	"github.com/juju/1.25-upgrade/juju2/instance"
+)
+
+func exportModel(st *state.State) (description.Model, error) {
+	model, err := st.Export()
+	if err != nil {
+		return nil, errors.Annotate(err, "exporting model representation")
+	}
+
+	if envCfg, err := st.EnvironConfig(); err != nil {
+		return nil, errors.Trace(err)
+	} else if envCfg.Type() == "maas" {
+		// Juju 1.25 doesn't have complete link-layer device definitions
+		// (it has network interfaces, but they lack some of the details)
+		// or IP addresses. Query MAAS for those using the Juju 2.x code,
+		// and fill in the blanks.
+		if err := addMAASNetworkEntities(model, st); err != nil {
+			return nil, errors.Annotate(err, "adding MAAS network entities")
+		}
+	}
+	return model, nil
+}
+
+// addMAASNetworkEntities adds link-layer devices and IP addresses to
+// the model description. These entities are not modeled by Juju 1.25,
+// so we take the model from 1.25 and augment it by using the Juju 2.x
+// MAAS provider code.
+func addMAASNetworkEntities(model description.Model, st *state.State) error {
+	envCfg, err := st.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	attrs := envCfg.AllAttrs()
+	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+		"maas-oauth": attrs["maas-oauth"].(string),
+	})
+	cloudSpec := environs.CloudSpec{
+		Type:       "maas",
+		Name:       model.Cloud(),
+		Region:     model.CloudRegion(),
+		Endpoint:   attrs["maas-server"].(string),
+		Credential: &cred,
+	}
+
+	modelCfg, err := config.New(config.NoDefaults, model.Config())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	env, err := environs.New(environs.OpenParams{cloudSpec, modelCfg})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	netenv := env.(environs.Networking)
+
+	// Add link-layer devices and IP addresses.
+	for _, machine := range model.Machines() {
+		inst := machine.Instance()
+		if inst == nil {
+			continue
+		}
+		instanceId := inst.InstanceId()
+		if instanceId == "" {
+			continue
+		}
+		interfaces, err := netenv.NetworkInterfaces(instance.Id(instanceId))
+		if err != nil {
+			return errors.Annotatef(err, "getting network interfaces for %q", instanceId)
+		}
+
+		networkConfig := networkingcommon.NetworkConfigFromInterfaceInfo(interfaces)
+		devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(networkConfig)
+		for _, d := range devicesArgs {
+			model.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
+				Name:        d.Name,
+				MTU:         d.MTU,
+				ProviderID:  string(d.ProviderID),
+				MachineID:   machine.Id(),
+				Type:        string(d.Type),
+				MACAddress:  d.MACAddress,
+				IsAutoStart: d.IsAutoStart,
+				IsUp:        d.IsUp,
+				ParentName:  d.ParentName,
+			})
+		}
+		for _, d := range devicesAddrs {
+			ip, ipNet, err := net.ParseCIDR(d.CIDRAddress)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			model.AddIPAddress(description.IPAddressArgs{
+				ProviderID:       string(d.ProviderID),
+				DeviceName:       d.DeviceName,
+				MachineID:        machine.Id(),
+				SubnetCIDR:       ipNet.String(),
+				ConfigMethod:     string(d.ConfigMethod),
+				Value:            ip.String(),
+				DNSServers:       d.DNSServers,
+				DNSSearchDomains: d.DNSSearchDomains,
+				GatewayAddress:   d.GatewayAddress,
+			})
+		}
+	}
+
+	return nil
+}

--- a/commands/import.go
+++ b/commands/import.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -199,7 +200,13 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 	for _, app := range model.Applications() {
 		usedCharms.Add(app.CharmURL())
 	}
-	return errors.Trace(transferCharms(st, usedCharms.SortedValues(), targetAPI))
+	err = transferCharms(st, usedCharms.SortedValues(), targetAPI)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	fmt.Fprintf(ctx.Stdout, "import completed successfully\n")
+	return nil
 }
 
 func updateToolsInModel(model description.Model, tw *toolsWrangler) ([]string, error) {

--- a/commands/import.go
+++ b/commands/import.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"github.com/juju/cmd"
+	"github.com/juju/description"
 	"github.com/juju/errors"
 
 	"github.com/juju/1.25-upgrade/juju2/api/migrationtarget"
@@ -103,13 +104,17 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 	targetAPI := migrationtarget.NewClient(conn)
 
 	logger.Debugf("exporting model from source environmment %s", st.EnvironTag().Id())
-	modelBytes, err := exportModel(st)
+	model, err := exportModel(st)
 	if err != nil {
 		return errors.Annotate(err, "exporting")
 	}
 
+	bytes, err := description.Serialize(model)
+	if err != nil {
+		return errors.Annotate(err, "serializing model representation")
+	}
 	logger.Debugf("importing model to target controller %s", conn.ControllerTag().Id())
-	err = targetAPI.Import(modelBytes)
+	err = targetAPI.Import(bytes)
 	// We want to try to clean up the model in the target even if
 	// there's an error importing - that can still leave the model
 	// around.

--- a/commands/import.go
+++ b/commands/import.go
@@ -1,0 +1,129 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/1.25-upgrade/juju2/api/migrationtarget"
+)
+
+var importDoc = `
+
+The import command converts the specified Juju 1.25 environment into
+the Juju 2.2.3 import format and imports it as a model under the
+target controller.
+
+All the agents in the source environment should be stopped before
+running the import command.
+
+`
+
+func newImportCommand() cmd.Command {
+	return wrap(&importCommand{
+		baseClientCommand{
+			needsController: true,
+			remoteCommand:   "import-impl",
+		},
+	})
+}
+
+type importCommand struct {
+	baseClientCommand
+}
+
+func (c *importCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "import",
+		Args:    "<environment name> <controller name>",
+		Purpose: "import the specified environment as a model in the target controller",
+		Doc:     importDoc,
+	}
+}
+
+func (c *importCommand) Init(args []string) error {
+	args, err := c.baseClientCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return cmd.CheckEmpty(args)
+}
+
+var importImplDoc = `
+
+import-impl must be run on an API server machine for a 1.25
+environment.
+
+It will convert the environment into the Juju 2.2.3 import format and
+import it as a model under the target controller.
+
+`
+
+func newImportImplCommand() cmd.Command {
+	return &importImplCommand{
+		baseRemoteCommand{needsController: true},
+	}
+}
+
+type importImplCommand struct {
+	baseRemoteCommand
+}
+
+func (c *importImplCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "import-impl",
+		Purpose: "controller-side command for the import command",
+		Doc:     importImplDoc,
+	}
+}
+
+func (c *importImplCommand) Init(args []string) error {
+	args, err := c.baseRemoteCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return cmd.CheckEmpty(args)
+}
+
+func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
+	st, err := c.getState(ctx)
+	if err != nil {
+		return errors.Annotate(err, "getting state")
+	}
+	defer st.Close()
+
+	conn, err := c.getControllerConnection()
+	if err != nil {
+		return errors.Annotate(err, "getting controller connection")
+	}
+	defer conn.Close()
+	targetAPI := migrationtarget.NewClient(conn)
+
+	logger.Debugf("exporting model from source environmment %s", st.EnvironTag().Id())
+	modelBytes, err := exportModel(st)
+	if err != nil {
+		return errors.Annotate(err, "exporting")
+	}
+
+	logger.Debugf("importing model to target controller %s", conn.ControllerTag().Id())
+	err = targetAPI.Import(modelBytes)
+	// We want to try to clean up the model in the target even if
+	// there's an error importing - that can still leave the model
+	// around.
+	defer func() {
+		if err != nil {
+			logger.Debugf("cleaning up failed import")
+			if cleanupErr := targetAPI.Abort(st.EnvironTag().Id()); cleanupErr != nil {
+				logger.Errorf("cleanup failed: %s", cleanupErr)
+			}
+		}
+	}()
+	if err != nil {
+		return errors.Annotate(err, "importing model on target controller")
+	}
+
+	return errors.Errorf("not finished")
+}

--- a/commands/import.go
+++ b/commands/import.go
@@ -175,6 +175,19 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Annotate(err, "importing model on target controller")
 	}
 
+	// Sanity check - ask the target controller whether the machines
+	// match what it expects.
+	checkResults, err := targetAPI.CheckMachines(model.Tag().Id())
+	if err != nil {
+		return errors.Annotate(err, "sanity checking machines in imported model")
+	}
+	if len(checkResults) > 0 {
+		for _, err := range checkResults {
+			logger.Errorf(err.Error())
+		}
+		return errors.Errorf("machine sanity check failed in imported model")
+	}
+
 	for _, seriesArch := range allTools {
 		err = tw.uploadTools(model.Tag().Id(), seriesArch)
 		if err != nil {

--- a/commands/import.go
+++ b/commands/import.go
@@ -264,6 +264,8 @@ func transferCharm(st *state.State, store storage.Storage, curlString string, ta
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer reader.Close()
+
 	localFile, err := ioutil.TempFile("", "charm-"+ch.URL().Name)
 	if err != nil {
 		return errors.Trace(err)

--- a/commands/main.go
+++ b/commands/main.go
@@ -57,4 +57,6 @@ func registerCommands(super *cmd.SuperCommand) {
 	super.Register(newRollbackAgentsImplCommand())
 	super.Register(newUpdateMAASAgentNameCommand())
 	super.Register(newUpdateMAASAgentNameImplCommand())
+	super.Register(newImportCommand())
+	super.Register(newImportImplCommand())
 }

--- a/commands/tools.go
+++ b/commands/tools.go
@@ -75,6 +75,10 @@ func (tw *toolsWrangler) getTools(seriesArch string) error {
 		return errors.Errorf("bad HTTP response: %v", resp.Status)
 	}
 
+	// Ensure the toolsDir exists.
+	if err := os.MkdirAll(toolsDir, 0755); err != nil {
+		return errors.Trace(err)
+	}
 	err = writeFile(downloadedTools, 0644, resp.Body)
 	if err != nil {
 		return errors.Errorf("cannot save tools: %v", err)

--- a/commands/tools.go
+++ b/commands/tools.go
@@ -1,0 +1,161 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"github.com/juju/version"
+
+	"github.com/juju/1.25-upgrade/juju2/api"
+	coretools "github.com/juju/1.25-upgrade/juju2/tools"
+)
+
+const toolsURLTemplate = "https://%s/tools/%s-%s"
+
+func newToolsWrangler(conn api.Connection) *toolsWrangler {
+	return &toolsWrangler{
+		conn:   conn,
+		client: utils.GetNonValidatingHTTPClient(),
+	}
+}
+
+type toolsWrangler struct {
+	conn   api.Connection
+	client *http.Client
+}
+
+func (w *toolsWrangler) version() string {
+	version, ok := w.conn.ServerVersion()
+	if !ok {
+		panic("can't download tools without logging into controller")
+	}
+	return version.String()
+}
+
+func (w *toolsWrangler) getTools(seriesArch string) error {
+	toolsURL := fmt.Sprintf(toolsURLTemplate, w.conn.Addr(), w.version(), seriesArch)
+	toolsVersion := version.MustParseBinary(w.version() + "-" + seriesArch)
+
+	// Look to see if the directory is already there, if it is, assume
+	// that it is good.
+	downloadedToolsDir := path.Join(toolsDir, toolsVersion.String())
+	if _, err := os.Stat(downloadedToolsDir); err == nil {
+		logger.Infof("%s exists\n", downloadedToolsDir)
+		return nil
+	}
+
+	logger.Infof("Downloading tools: %s\n", toolsURL)
+	resp, err := w.client.Get(toolsURL)
+	if err != nil {
+		return errors.Annotatef(err, "downloading tools %s", toolsVersion)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("bad HTTP response: %v", resp.Status)
+	}
+
+	err = UnpackTools(toolsDir, toolsVersion, resp.Body)
+	if err != nil {
+		return errors.Errorf("cannot unpack tools: %v", err)
+	}
+	return nil
+
+}
+
+// UnpackTools reads a set of juju tools in gzipped tar-archive
+// format and unpacks them into the appropriate tools directory
+// within dataDir. If a valid tools directory already exists,
+// UnpackTools returns without error.
+func UnpackTools(dataDir string, toolsVersion version.Binary, r io.Reader) (err error) {
+	// Unpack the gzip file and compute the checksum.
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+	f, err := ioutil.TempFile(os.TempDir(), "tools-tar")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, zr)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+
+	// Make a temporary directory in the tools directory,
+	// first ensuring that the tools directory exists.
+	dir, err := ioutil.TempDir(toolsDir, "unpacking-")
+	if err != nil {
+		return err
+	}
+	defer removeAll(dir)
+
+	// Checksum matches, now reset the file and untar it.
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if strings.ContainsAny(hdr.Name, "/\\") {
+			return fmt.Errorf("bad name %q in tools archive", hdr.Name)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			return fmt.Errorf("bad file type %c in file %q in tools archive", hdr.Typeflag, hdr.Name)
+		}
+		name := path.Join(dir, hdr.Name)
+		if err := writeFile(name, os.FileMode(hdr.Mode&0777), tr); err != nil {
+			return errors.Annotatef(err, "tar extract %q failed", name)
+		}
+	}
+	// Write some metadata about the tools.
+	tools := &coretools.Tools{Version: toolsVersion}
+	toolsMetadataData, err := json.Marshal(tools)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(path.Join(dir, toolsFile), toolsMetadataData, 0644)
+	if err != nil {
+		return err
+	}
+
+	// The tempdir is created with 0700, so we need to make it more
+	// accessable for juju-run.
+	err = os.Chmod(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(dir, path.Join(toolsDir, toolsVersion.String()))
+}
+
+func writeFile(name string, mode os.FileMode, r io.Reader) error {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, r)
+	return err
+}

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -116,11 +116,6 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
 
-	// Make a dir to put the downloaded tools into.
-	if err := os.MkdirAll(toolsDir, 0755); err != nil {
-		return errors.Trace(err)
-	}
-
 	// Save machine addresses so that we don't need to be able to talk
 	// to the database to rollback the agent upgrades.
 	if err := c.saveMachines(machines); err != nil {
@@ -176,6 +171,10 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *upgradeAgentsImplCommand) saveMachines(machines []FlatMachine) error {
+	// Ensure the toolsDir exists.
+	if err := os.MkdirAll(toolsDir, 0755); err != nil {
+		return errors.Trace(err)
+	}
 	fileData, err := json.Marshal(machines)
 	if err != nil {
 		return errors.Trace(err)

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -4,17 +4,12 @@
 package commands
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
-	"strings"
 	"text/template"
 
 	"github.com/juju/cmd"
@@ -26,7 +21,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/juju/1.25-upgrade/juju2/api"
-	coretools "github.com/juju/1.25-upgrade/juju2/tools"
 )
 
 //go:generate go run ../juju2/generate/filetoconst/filetoconst.go agentUpgradeScript agent-upgrade.py agentupgrade_script.go 2017 commands
@@ -163,11 +157,10 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Get the tools from the controller.
-	client := utils.GetNonValidatingHTTPClient()
-	toolsURLPrefix := fmt.Sprintf("https://%s/tools/%s-", conn.Addr(), ver)
+	tw := newToolsWrangler(conn)
 	for _, seriesArch := range toolsNeeded.SortedValues() {
-		if err := c.getTools(ctx, client, ver, toolsURLPrefix, seriesArch); err != nil {
-			return errors.Annotatef(err, "downloading tools %s-%s", ver, seriesArch)
+		if err := tw.getTools(seriesArch); err != nil {
+			return errors.Trace(err)
 		}
 	}
 
@@ -182,35 +175,6 @@ func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	return errors.Trace(reportResults(ctx, "upgrade", machines, results))
-}
-
-func (c *upgradeAgentsImplCommand) getTools(ctx *cmd.Context, client *http.Client, ver version.Number, toolsURLPrefix, seriesArch string) error {
-	toolsUrl := toolsURLPrefix + seriesArch
-	toolsVersion := version.MustParseBinary(ver.String() + "-" + seriesArch)
-
-	// Look to see if the directory is already there, if it is, assume
-	// that it is good.
-	downloadedToolsDir := path.Join(toolsDir, toolsVersion.String())
-	if _, err := os.Stat(downloadedToolsDir); err == nil {
-		fmt.Fprintf(ctx.Stdout, "%s exists\n", downloadedToolsDir)
-		return nil
-	}
-
-	fmt.Fprintf(ctx.Stdout, "Downloading tools: %s\n", toolsUrl)
-	resp, err := client.Get(toolsUrl)
-	if err != nil {
-		return errors.Annotate(err, "downloading tools")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("bad HTTP response: %v", resp.Status)
-	}
-
-	err = UnpackTools(toolsDir, toolsVersion, resp.Body)
-	if err != nil {
-		return errors.Errorf("cannot unpack tools: %v", err)
-	}
-	return nil
 }
 
 func (c *upgradeAgentsImplCommand) saveMachines(machines []FlatMachine) error {
@@ -279,98 +243,12 @@ func (c *upgradeAgentsImplCommand) writeUpgradeScript(config *scriptConfig) (str
 	}
 	return scriptPath, nil
 }
-
-// UnpackTools reads a set of juju tools in gzipped tar-archive
-// format and unpacks them into the appropriate tools directory
-// within dataDir. If a valid tools directory already exists,
-// UnpackTools returns without error.
-func UnpackTools(dataDir string, toolsVersion version.Binary, r io.Reader) (err error) {
-	// Unpack the gzip file and compute the checksum.
-	zr, err := gzip.NewReader(r)
-	if err != nil {
-		return err
-	}
-	defer zr.Close()
-	f, err := ioutil.TempFile(os.TempDir(), "tools-tar")
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(f, zr)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(f.Name())
-
-	// Make a temporary directory in the tools directory,
-	// first ensuring that the tools directory exists.
-	dir, err := ioutil.TempDir(toolsDir, "unpacking-")
-	if err != nil {
-		return err
-	}
-	defer removeAll(dir)
-
-	// Checksum matches, now reset the file and untar it.
-	_, err = f.Seek(0, 0)
-	if err != nil {
-		return err
-	}
-	tr := tar.NewReader(f)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if strings.ContainsAny(hdr.Name, "/\\") {
-			return fmt.Errorf("bad name %q in tools archive", hdr.Name)
-		}
-		if hdr.Typeflag != tar.TypeReg {
-			return fmt.Errorf("bad file type %c in file %q in tools archive", hdr.Typeflag, hdr.Name)
-		}
-		name := path.Join(dir, hdr.Name)
-		if err := writeFile(name, os.FileMode(hdr.Mode&0777), tr); err != nil {
-			return errors.Annotatef(err, "tar extract %q failed", name)
-		}
-	}
-	// Write some metadata about the tools.
-	tools := &coretools.Tools{Version: toolsVersion}
-	toolsMetadataData, err := json.Marshal(tools)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(path.Join(dir, toolsFile), []byte(toolsMetadataData), 0644)
-	if err != nil {
-		return err
-	}
-
-	// The tempdir is created with 0700, so we need to make it more
-	// accessable for juju-run.
-	err = os.Chmod(dir, 0755)
-	if err != nil {
-		return err
-	}
-
-	return os.Rename(dir, path.Join(toolsDir, toolsVersion.String()))
-}
-
 func removeAll(dir string) {
 	err := os.RemoveAll(dir)
 	if err == nil || os.IsNotExist(err) {
 		return
 	}
 	logger.Errorf("cannot remove %q: %v", dir, err)
-}
-
-func writeFile(name string, mode os.FileMode, r io.Reader) error {
-	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = io.Copy(f, r)
-	return err
 }
 
 func seriesArch(machine FlatMachine) string {

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -212,7 +212,7 @@ func (c *upgradeAgentsImplCommand) pushToolsToMachine(ctx *cmd.Context, ver vers
 	if rc != 0 {
 		return &cmd.RcPassthroughError{Code: rc}
 	}
-	toolsPath := toolsFilePath(ver.String(), seriesArch(machine))
+	toolsPath := toolsFilePath(ver, seriesArch(machine))
 	options := defaultSSHOptions()
 	options.SetIdentities(systemIdentity)
 	logger.Debugf("copying upgrade script and %s to machine %s", toolsPath, machine.ID)

--- a/commands/verifysource.go
+++ b/commands/verifysource.go
@@ -4,15 +4,9 @@
 package commands
 
 import (
-	"net"
 	"strings"
 
 	"github.com/juju/1.25-upgrade/juju1/state"
-	"github.com/juju/1.25-upgrade/juju2/apiserver/common/networkingcommon"
-	"github.com/juju/1.25-upgrade/juju2/cloud"
-	"github.com/juju/1.25-upgrade/juju2/environs"
-	"github.com/juju/1.25-upgrade/juju2/environs/config"
-	"github.com/juju/1.25-upgrade/juju2/instance"
 	_ "github.com/juju/1.25-upgrade/juju2/provider/maas"
 	"github.com/juju/cmd"
 	"github.com/juju/description"
@@ -112,122 +106,19 @@ func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
 	return errors.Annotate(writeModel(ctx, st), "exporting model")
 }
 
-func exportModel(st *state.State) ([]byte, error) {
-	model, err := st.Export()
+func writeModel(ctx *cmd.Context, st *state.State) error {
+	model, err := exportModel(st)
 	if err != nil {
-		return nil, errors.Annotate(err, "exporting model representation")
-	}
-
-	if envCfg, err := st.EnvironConfig(); err != nil {
-		return nil, errors.Trace(err)
-	} else if envCfg.Type() == "maas" {
-		// Juju 1.25 doesn't have complete link-layer device definitions
-		// (it has network interfaces, but they lack some of the details)
-		// or IP addresses. Query MAAS for those using the Juju 2.x code,
-		// and fill in the blanks.
-		if err := addMAASNetworkEntities(model, st); err != nil {
-			return nil, errors.Annotate(err, "adding MAAS network entities")
-		}
+		return errors.Trace(err)
 	}
 	bytes, err := description.Serialize(model)
 	if err != nil {
-		return nil, errors.Annotate(err, "serializing model representation")
-	}
-	return bytes, nil
-}
-
-func writeModel(ctx *cmd.Context, st *state.State) error {
-	bytes, err := exportModel(st)
-	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "serializing model representation")
 	}
 
 	_, err = ctx.GetStdout().Write(bytes)
 	if err != nil {
 		return errors.Annotate(err, "writing model representation")
-	}
-
-	return nil
-}
-
-// addMAASNetworkEntities adds link-layer devices and IP addresses to
-// the model description. These entities are not modeled by Juju 1.25,
-// so we take the model from 1.25 and augment it by using the Juju 2.x
-// MAAS provider code.
-func addMAASNetworkEntities(model description.Model, st *state.State) error {
-	envCfg, err := st.EnvironConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	attrs := envCfg.AllAttrs()
-	cred := cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
-		"maas-oauth": attrs["maas-oauth"].(string),
-	})
-	cloudSpec := environs.CloudSpec{
-		Type:       "maas",
-		Name:       model.Cloud(),
-		Region:     model.CloudRegion(),
-		Endpoint:   attrs["maas-server"].(string),
-		Credential: &cred,
-	}
-
-	modelCfg, err := config.New(config.NoDefaults, model.Config())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	env, err := environs.New(environs.OpenParams{cloudSpec, modelCfg})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	netenv := env.(environs.Networking)
-
-	// Add link-layer devices and IP addresses.
-	for _, machine := range model.Machines() {
-		inst := machine.Instance()
-		if inst == nil {
-			continue
-		}
-		instanceId := inst.InstanceId()
-		if instanceId == "" {
-			continue
-		}
-		interfaces, err := netenv.NetworkInterfaces(instance.Id(instanceId))
-		if err != nil {
-			return errors.Annotatef(err, "getting network interfaces for %q", instanceId)
-		}
-
-		networkConfig := networkingcommon.NetworkConfigFromInterfaceInfo(interfaces)
-		devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(networkConfig)
-		for _, d := range devicesArgs {
-			model.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
-				Name:        d.Name,
-				MTU:         d.MTU,
-				ProviderID:  string(d.ProviderID),
-				MachineID:   machine.Id(),
-				Type:        string(d.Type),
-				MACAddress:  d.MACAddress,
-				IsAutoStart: d.IsAutoStart,
-				IsUp:        d.IsUp,
-				ParentName:  d.ParentName,
-			})
-		}
-		for _, d := range devicesAddrs {
-			ip, ipNet, err := net.ParseCIDR(d.CIDRAddress)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			model.AddIPAddress(description.IPAddressArgs{
-				ProviderID:       string(d.ProviderID),
-				DeviceName:       d.DeviceName,
-				MachineID:        machine.Id(),
-				SubnetCIDR:       ipNet.String(),
-				ConfigMethod:     string(d.ConfigMethod),
-				Value:            ip.String(),
-				DNSServers:       d.DNSServers,
-				DNSSearchDomains: d.DNSSearchDomains,
-				GatewayAddress:   d.GatewayAddress,
-			})
-		}
 	}
 
 	return nil

--- a/commands/verifysource.go
+++ b/commands/verifysource.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"strings"
 
-	"github.com/juju/1.25-upgrade/juju1/state"
 	_ "github.com/juju/1.25-upgrade/juju2/provider/maas"
 	"github.com/juju/cmd"
 	"github.com/juju/description"
@@ -103,14 +102,14 @@ func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "dry-running LXC migration")
 	}
 
-	return errors.Annotate(writeModel(ctx, st), "exporting model")
-}
-
-func writeModel(ctx *cmd.Context, st *state.State) error {
 	model, err := exportModel(st)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "exporting model")
 	}
+	return errors.Annotate(writeModel(ctx, model), "writing model")
+}
+
+func writeModel(ctx *cmd.Context, model description.Model) error {
 	bytes, err := description.Serialize(model)
 	if err != nil {
 		return errors.Annotate(err, "serializing model representation")

--- a/juju2/api/migrationtarget/client.go
+++ b/juju2/api/migrationtarget/client.go
@@ -227,3 +227,19 @@ func (c *Client) AdoptResources(modelUUID string) error {
 func (c *Client) CACert() (string, error) {
 	return common.NewAPIAddresser(c.caller).CACert()
 }
+
+// CheckMachines compares the machines in state with the ones reported
+// by the provider and reports any discrepancies.
+func (c *Client) CheckMachines(modelUUID string) ([]error, error) {
+	var result params.ErrorResults
+	args := params.ModelArgs{names.NewModelTag(modelUUID).String()}
+	err := c.caller.FacadeCall("CheckMachines", args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var results []error
+	for _, res := range result.Results {
+		results = append(results, errors.Errorf(res.Error.Message))
+	}
+	return results, nil
+}


### PR DESCRIPTION
This exports the 1.25 environment into the 2.2.3 description, updates the tools for machines and units in the exported model, then imports the model on the target controller. It also uploads tools and charms. 

There will be a separate command to activate the imported model once the agents have been upgraded (and checked that they can connect to the model).