### PR TITLE
Change start/stop/status to use saved machines if available

### DIFF
--- a/commands/activate.go
+++ b/commands/activate.go
@@ -1,0 +1,122 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/1.25-upgrade/juju2/agent"
+	"github.com/juju/1.25-upgrade/juju2/api/migrationtarget"
+)
+
+var activateDoc = `
+
+The activate command enables the newly-imported model in the target
+controller. It should only be run after upgrading the agents (which
+includes a check that each agent can connect to the new model's API).
+
+`
+
+func newActivateCommand() cmd.Command {
+	command := &activateCommand{}
+	command.remoteCommand = "activate-impl"
+	command.needsController = true
+	return wrap(command)
+}
+
+type activateCommand struct {
+	baseClientCommand
+}
+
+func (c *activateCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "activate",
+		Args:    "<environment name>",
+		Purpose: "activate the new model in the target controller",
+		Doc:     activateDoc,
+	}
+}
+
+func (c *activateCommand) Init(args []string) error {
+	args, err := c.baseClientCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return cmd.CheckEmpty(args)
+}
+
+var activateImplDoc = `
+
+activate-impl must be executed on an API server machine of a 1.25
+environment.
+
+The command will roll back the effects of a previous upgrade-agents
+command.
+
+`
+
+func newActivateImplCommand() cmd.Command {
+	return &activateImplCommand{
+		baseRemoteCommand{needsController: true},
+	}
+}
+
+type activateImplCommand struct {
+	baseRemoteCommand
+}
+
+func (c *activateImplCommand) Init(args []string) error {
+	args, err := c.baseRemoteCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return cmd.CheckEmpty(args)
+}
+
+func (c *activateImplCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "activate-impl",
+		Purpose: "controller aspect of activate",
+		Doc:     activateImplDoc,
+	}
+}
+
+func (c *activateImplCommand) Run(ctx *cmd.Context) error {
+	conn, err := c.getControllerConnection()
+	if err != nil {
+		return errors.Annotate(err, "getting controller connection")
+	}
+	defer conn.Close()
+	targetAPI := migrationtarget.NewClient(conn)
+
+	modelUUID, err := getModelUUID()
+	if err != nil {
+		return errors.Annotate(err, "getting model UUID")
+	}
+
+	err = targetAPI.Activate(modelUUID)
+	if err != nil {
+		return errors.Annotate(err, "activating new model")
+	}
+	fmt.Fprintf(ctx.Stdout, "model %q activated\n", modelUUID)
+	return nil
+}
+
+func getModelUUID() (string, error) {
+	tag, err := getCurrentMachineTag(dataDir)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// Use the juju2 agent code to read the config, since this should
+	// be run after upgrading the agents.
+	config, err := agent.ReadConfig(agent.ConfigPath(dataDir, tag))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return config.Model().Id(), nil
+}

--- a/commands/backuplxc.go
+++ b/commands/backuplxc.go
@@ -175,7 +175,7 @@ func (c *backupLXCImplCommand) Init(args []string) error {
 }
 
 func (c *backupLXCImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/baseremote.go
+++ b/commands/baseremote.go
@@ -75,7 +75,7 @@ func (c *baseRemoteCommand) getControllerConnection() (api.Connection, error) {
 	return api.Open(c.controllerInfo, api.DefaultDialOpts())
 }
 
-func (c *baseRemoteCommand) getState(ctx *cmd.Context) (*state.State, error) {
+func getState() (*state.State, error) {
 	tag, err := getCurrentMachineTag(dataDir)
 	if err != nil {
 		return nil, errors.Annotate(err, "finding machine tag")

--- a/commands/dumpsourcedb.go
+++ b/commands/dumpsourcedb.go
@@ -58,7 +58,7 @@ func (c *dumpSourceDBImpl) Info() *cmd.Info {
 }
 
 func (c *dumpSourceDBImpl) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/import.go
+++ b/commands/import.go
@@ -122,7 +122,7 @@ func (c *importImplCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/main.go
+++ b/commands/main.go
@@ -59,4 +59,6 @@ func registerCommands(super *cmd.SuperCommand) {
 	super.Register(newUpdateMAASAgentNameImplCommand())
 	super.Register(newImportCommand())
 	super.Register(newImportImplCommand())
+	super.Register(newActivateCommand())
+	super.Register(newActivateImplCommand())
 }

--- a/commands/migratelxc.go
+++ b/commands/migratelxc.go
@@ -77,7 +77,7 @@ func (c *migrateLXCImplCommand) Info() *cmd.Info {
 }
 
 func (c *migrateLXCImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/rollbackagents.go
+++ b/commands/rollbackagents.go
@@ -4,10 +4,6 @@
 package commands
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"path"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 )
@@ -76,7 +72,7 @@ func (c *rollbackAgentsImplCommand) Info() *cmd.Info {
 }
 
 func (c *rollbackAgentsImplCommand) Run(ctx *cmd.Context) error {
-	machines, err := c.loadMachines()
+	machines, err := loadMachines()
 	if err != nil {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}
@@ -86,17 +82,4 @@ func (c *rollbackAgentsImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	return errors.Trace(reportResults(ctx, "rollback", machines, results))
-}
-
-func (c *rollbackAgentsImplCommand) loadMachines() ([]FlatMachine, error) {
-	data, err := ioutil.ReadFile(path.Join(toolsDir, "saved-machines.json"))
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var machines []FlatMachine
-	err = json.Unmarshal(data, &machines)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return machines, nil
 }

--- a/commands/startagents.go
+++ b/commands/startagents.go
@@ -67,18 +67,9 @@ func (c *startAgentsImplCommand) Info() *cmd.Info {
 }
 
 func (c *startAgentsImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	machines, err := loadMachines()
 	if err != nil {
-		return errors.Annotate(err, "getting state")
-	}
-	defer st.Close()
-
-	// Here we always use the 1.25 environment to get all of the machine
-	// addresses. We then use those to ssh into every one of those machine
-	// and run the service status script against all the agents.
-	machines, err := getMachines(st)
-	if err != nil {
-		return errors.Annotate(err, "unable to get addresses for machines")
+		return errors.Annotate(err, "getting machines")
 	}
 
 	if _, err := agentServiceCommand(ctx, machines, "start"); err != nil {

--- a/commands/stopagents.go
+++ b/commands/stopagents.go
@@ -67,16 +67,7 @@ func (c *stopAgentsImplCommand) Info() *cmd.Info {
 }
 
 func (c *stopAgentsImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
-	if err != nil {
-		return errors.Annotate(err, "getting state")
-	}
-	defer st.Close()
-
-	// Here we always use the 1.25 environment to get all of the machine
-	// addresses. We then use those to ssh into every one of those machine
-	// and run the service status script against all the agents.
-	machines, err := getMachines(st)
+	machines, err := loadMachines()
 	if err != nil {
 		return errors.Annotate(err, "unable to get addresses for machines")
 	}

--- a/commands/update-maas-agentname.go
+++ b/commands/update-maas-agentname.go
@@ -75,7 +75,7 @@ func (c *updateMAASAgentNameImplCommand) Info() *cmd.Info {
 }
 
 func (c *updateMAASAgentNameImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/upgradeagents.go
+++ b/commands/upgradeagents.go
@@ -102,7 +102,7 @@ func (c *upgradeAgentsImplCommand) Info() *cmd.Info {
 }
 
 func (c *upgradeAgentsImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}

--- a/commands/verifysource.go
+++ b/commands/verifysource.go
@@ -73,7 +73,7 @@ func (c *verifySourceImplCommand) Info() *cmd.Info {
 }
 
 func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
-	st, err := c.getState(ctx)
+	st, err := getState()
 	if err != nil {
 		return errors.Annotate(err, "getting state")
 	}


### PR DESCRIPTION
If the saved machines file is present, it means that the agents have been upgraded, so getting the state to list machines won't work. This means we can use start-agents after running activate to get everything running again.