### PR TITLE
Check connectivity from agents after upgrading

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -148,6 +148,9 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	model.Config()["agent-version"] = tw.version()
+
 	if logger.IsDebugEnabled() {
 		err = writeModel(ctx, model)
 		if err != nil {


### PR DESCRIPTION
This will run `tools/<agent>/jujud check-connection <agent-name>` for each agent on each machine and report any errors that come back.

Also update the model's agent version before importing it - otherwise adding a new machine would fail after the import because it would install the 1.25 tools but use version 2 config.