### PR TITLE
Add --target-cloud to the import command

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -17,8 +17,8 @@ import (
 	"github.com/juju/1.25-upgrade/juju2/instance"
 )
 
-func exportModel(st *state.State) (description.Model, error) {
-	model, err := st.Export()
+func exportModel(st *state.State, targetCloud string) (description.Model, error) {
+	model, err := st.Export(targetCloud)
 	if err != nil {
 		return nil, errors.Annotate(err, "exporting model representation")
 	}

--- a/commands/import.go
+++ b/commands/import.go
@@ -45,7 +45,8 @@ func newImportCommand() cmd.Command {
 type importCommand struct {
 	baseClientCommand
 
-	keepBroken bool
+	keepBroken  bool
+	targetCloud string
 }
 
 func (c *importCommand) Info() *cmd.Info {
@@ -68,11 +69,15 @@ func (c *importCommand) Init(args []string) error {
 func (c *importCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.baseClientCommand.SetFlags(f)
 	f.BoolVar(&c.keepBroken, "keep-broken", false, "Keep a failed import")
+	f.StringVar(&c.targetCloud, "target-cloud", "", "The name of the cloud in the target controller")
 }
 
 func (c *importCommand) Run(ctx *cmd.Context) error {
 	if c.keepBroken {
 		c.extraOptions = append(c.extraOptions, "--keep-broken")
+	}
+	if c.targetCloud != "" {
+		c.extraOptions = append(c.extraOptions, "--target-cloud", c.targetCloud)
 	}
 	return c.baseClientCommand.Run(ctx)
 }
@@ -96,7 +101,8 @@ func newImportImplCommand() cmd.Command {
 type importImplCommand struct {
 	baseRemoteCommand
 
-	keepBroken bool
+	keepBroken  bool
+	targetCloud string
 }
 
 func (c *importImplCommand) Info() *cmd.Info {
@@ -119,6 +125,7 @@ func (c *importImplCommand) Init(args []string) error {
 func (c *importImplCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.baseRemoteCommand.SetFlags(f)
 	f.BoolVar(&c.keepBroken, "keep-broken", false, "Keep a failed import")
+	f.StringVar(&c.targetCloud, "target-cloud", "", "The name of the cloud in the target controller")
 }
 
 func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
@@ -136,7 +143,7 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 	targetAPI := migrationtarget.NewClient(conn)
 
 	logger.Debugf("exporting model from source environmment %s", st.EnvironTag().Id())
-	model, err := exportModel(st)
+	model, err := exportModel(st, c.targetCloud)
 	if err != nil {
 		return errors.Annotate(err, "exporting")
 	}

--- a/commands/verifysource.go
+++ b/commands/verifysource.go
@@ -102,7 +102,7 @@ func (c *verifySourceImplCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "dry-running LXC migration")
 	}
 
-	model, err := exportModel(st)
+	model, err := exportModel(st, "")
 	if err != nil {
 		return errors.Annotate(err, "exporting model")
 	}

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -51,7 +51,7 @@ var storageProviderTypeMap = map[string]storage.ProviderType{
 }
 
 // Export the current model for the State.
-func (st *State) Export() (description.Model, error) {
+func (st *State) Export(overrideCloud string) (description.Model, error) {
 	dbModel, err := st.Environment()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -104,6 +104,10 @@ func (st *State) Export() (description.Model, error) {
 		Owner:       creds.Owner,
 		Config:      modelConfig,
 		Blocks:      blocks,
+	}
+	if overrideCloud != "" {
+		args.Cloud = overrideCloud
+		creds.Cloud = names2.NewCloudTag(overrideCloud)
 	}
 	export.model = description.NewModel(args)
 	export.model.SetCloudCredential(creds)


### PR DESCRIPTION
This allows the import to work when the source env cloud name is different from the target cloud name (although they still need to refer to the same actual cloud, or the post-import sanity check will fail).