### PR TITLE
Upgrade provider tagging while importing

### DIFF
--- a/commands/activate.go
+++ b/commands/activate.go
@@ -103,7 +103,13 @@ func (c *activateImplCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "activating new model")
 	}
-	fmt.Fprintf(ctx.Stdout, "model %q activated\n", modelUUID)
+	fmt.Fprintf(ctx.Stdout, "model %s activated\n", modelUUID)
+
+	err = targetAPI.AdoptResources(modelUUID)
+	if err != nil {
+		return errors.Annotate(err, "adopting resources")
+	}
+	fmt.Fprintf(ctx.Stdout, "model %s resources adopted by target controller\n", modelUUID)
 	return nil
 }
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -186,6 +186,14 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Annotate(err, "importing model on target controller")
 	}
 
+	// We need to upgrade the tags in the environment before checking
+	// machines, since in most providers that's how we determine which
+	// instances belong to this environment/model.
+	err = upgradeTags(st)
+	if err != nil {
+		return errors.Annotate(err, "upgrading environment tags")
+	}
+
 	// Sanity check - ask the target controller whether the machines
 	// match what it expects.
 	checkResults, err := targetAPI.CheckMachines(model.Tag().Id())

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/1.25-upgrade/juju1/environs"
+	"github.com/juju/1.25-upgrade/juju1/state"
+)
+
+// TagUpgrader will be implemented by providers to enable us to update
+// the specific tags they store. Making upgrade and downgrade methods
+// on the same interface so we can be sure that we only upgrade tags
+// when we know we can downgrade them again.
+type TagUpgrader interface {
+	// UpgradeTags replaces juju-env-uuid tags with juju-model-uuid on
+	// any resources that need updating.
+	UpgradeTags() error
+	// Downgrade tags converts juju-model-uuid tags back to
+	// juju-env-uuid, and removes any juju-controller-uuid tags.
+	DowngradeTags() error
+}
+
+func getTagUpgrader(st *state.State) (TagUpgrader, error) {
+	e, err := st.Environment()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	config, err := e.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env, err := environs.New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	upgrader, ok := env.(TagUpgrader)
+	if !ok {
+		return nil, errors.Errorf("%q (type=%s) environ doesn't support upgrading tags", e.Name(), config.Type())
+	}
+	return upgrader, nil
+}
+
+func upgradeTags(st *state.State) error {
+	upgrader, err := getTagUpgrader(st)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return upgrader.UpgradeTags()
+}
+
+func downgradeTags(st *state.State) error {
+	upgrader, err := getTagUpgrader(st)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return upgrader.DowngradeTags()
+}

--- a/juju1/provider/maas/environ.go
+++ b/juju1/provider/maas/environ.go
@@ -2016,3 +2016,15 @@ func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]iface
 	err := processNodes(lshw.Nodes)
 	return interfaces, primaryIface, err
 }
+
+// UpgradeTags is part of the TagUpgrader interface.
+func (environ *maasEnviron) UpgradeTags() error {
+	// We don't track machines in environments by tag in MAAS 1.9.
+	return nil
+}
+
+// DowngradeTags is part of the TagUpgrader interface.
+func (environ *maasEnviron) DowngradeTags() error {
+	// We don't track machines in environments by tag in MAAS 1.9.
+	return nil
+}


### PR DESCRIPTION
Before the machine sanity check at the end of the import can succeed we need to update the provider's tags on the instances to match what Juju 2 expects so that the target controller can find them. The tagging is provider-specific, so each provider that we support in the upgrade will need to implement the `TagUpgrader` interface.

Add code to import to upgrade the tags before checking machines between the provider and new model. Add downgrading the tags to the abort command. Also call `AdoptResources` on the newly imported model after activating it.

(I had done an implementation of `TagUpgrader` for the ec2 provider, but testing showed that we need to rename security groups as well for that to work, so I've backed that out until we need it, if ever.)