### PR TITLE
Convert service sequences to application ones

### DIFF
--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -292,7 +292,13 @@ func (e *exporter) sequences() error {
 	}
 
 	for _, doc := range docs {
-		e.model.SetSequence(doc.Name, doc.Counter)
+		name := doc.Name
+		// Rename any service sequences to be application sequences.
+		if svcTag, err := names1.ParseServiceTag(doc.Name); err == nil {
+			appTag := names2.NewApplicationTag(svcTag.Id())
+			name = appTag.String()
+		}
+		e.model.SetSequence(name, doc.Counter)
 	}
 	return nil
 }


### PR DESCRIPTION
Ensure the sequences are imported with the right names so that they work after migration.