### PR TITLE
restore-lxc: add restore-lxc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ provider tagging if relevant.
 
 Note that the migrate-lxc command does not store backups on the hosts,
 as the hosts may not have sufficient disk space for duplicate root
-filesystems. If an error occurs, then you will have to copy the backups
-to the hosts, and reinstate the LXC containers.
+filesystems. If an error occurs, then you will also have to restore
+the LXC containers:
 
-After aborting the upgrade, you should start the
-agents back up:
+    juju 1.25-upgrade restore-lxc <envname> <backup-dir>
+
+After aborting the upgrade, you should start the agents back up:
 
     juju 1.25-upgrade start-agents <envname>

--- a/commands/exec.go
+++ b/commands/exec.go
@@ -19,6 +19,7 @@ const systemIdentity = "/var/lib/juju/system-identity"
 
 type execOptions struct {
 	ssh.Options
+	stdin  io.Reader
 	stdout io.Writer
 	stderr io.Writer
 }
@@ -32,6 +33,12 @@ func withSystemIdentity() execOption {
 func withIdentity(identity string) execOption {
 	return func(opts *execOptions) {
 		opts.SetIdentities(identity)
+	}
+}
+
+func withStdin(r io.Reader) execOption {
+	return func(opts *execOptions) {
+		opts.stdin = r
 	}
 }
 
@@ -92,6 +99,7 @@ func runViaSSH(addr, script string, opts ...execOption) (int, error) {
 		[]string{"sudo", "-n", "bash", "-c " + utils.ShQuote(script)},
 		&options.Options,
 	)
+	userCmd.Stdin = options.stdin
 	userCmd.Stdout = options.stdout
 	userCmd.Stderr = options.stderr
 

--- a/commands/lxc2lxd.go
+++ b/commands/lxc2lxd.go
@@ -172,6 +172,28 @@ func BackupLXCContainer(container, host *state.Machine, out io.Writer) error {
 	return nil
 }
 
+// RestoreLXCContainer restores the specified container's rootfs from an
+// archive, read from the given writer.
+func RestoreLXCContainer(container, host *state.Machine, in io.Reader) error {
+	hostAddr, err := getMachineAddress(host)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rc, err := runViaSSH(
+		hostAddr,
+		"tar -C /var/lib/lxc -xJ ",
+		withSystemIdentity(),
+		withStdin(in),
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if rc != 0 {
+		return errors.Errorf("restoring LXC container exited %d", rc)
+	}
+	return nil
+}
+
 // StartLXCContainer starts the specified LXD container machine.
 func StartLXDContainers(containerNames []string, host *state.Machine) error {
 	hostAddr, err := getMachineAddress(host)

--- a/commands/main.go
+++ b/commands/main.go
@@ -51,6 +51,8 @@ func registerCommands(super *cmd.SuperCommand) {
 	super.Register(newUpgradeAgentsImplCommand())
 	super.Register(newBackupLXCCommand())
 	super.Register(newBackupLXCImplCommand())
+	super.Register(newRestoreLXCCommand())
+	super.Register(newRestoreLXCImplCommand())
 	super.Register(newMigrateLXCCommand())
 	super.Register(newMigrateLXCImplCommand())
 	super.Register(newAbortCommand())

--- a/commands/restorelxc.go
+++ b/commands/restorelxc.go
@@ -1,0 +1,212 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"golang.org/x/sync/errgroup"
+)
+
+var restoreLXCDoc = ` 
+The purpose of the restore-lxc command is to restore a backup of
+the LXC containers in a 1.25 environment.
+
+If --match is specified, it is treated as a regular expression for
+matching container names. Only containers whose names match will
+be restored.
+
+If --dry-run is specified, then no changes will take place.
+`
+
+func newRestoreLXCCommand() cmd.Command {
+	command := &restoreLXCCommand{}
+	command.remoteCommand = "restore-lxc-impl"
+	return wrap(command)
+}
+
+type restoreLXCCommand struct {
+	baseClientCommand
+	backupDir string
+	dryRun    bool
+	match     string
+}
+
+func (c *restoreLXCCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "restore-lxc",
+		Args:    "<environment name> <backup dir>",
+		Purpose: "restore LXC containers for the specified environment",
+		Doc:     restoreLXCDoc,
+	}
+}
+
+func (c *restoreLXCCommand) Init(args []string) error {
+	args, err := c.baseClientCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(args) == 0 {
+		return errors.New("no backup directory specified")
+	}
+	c.backupDir, args = args[0], args[1:]
+	return cmd.CheckEmpty(args)
+}
+
+func (c *restoreLXCCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.baseClientCommand.SetFlags(f)
+	f.BoolVar(&c.dryRun, "dry-run", false, "perform a dry run, without making any changes")
+	f.StringVar(&c.match, "match", "", "regular expression for matching LXC container IDs to restore")
+}
+
+func (c *restoreLXCCommand) Run(ctx *cmd.Context) error {
+	if _, err := os.Stat(c.backupDir); err != nil {
+		return errors.Annotate(err, "checking restore dir")
+	}
+
+	match := func(string) bool { return true }
+	if c.match != "" {
+		matchRE, err := regexp.Compile(c.match)
+		if err != nil {
+			return errors.Annotate(err, "parsing --match")
+		}
+		match = matchRE.MatchString
+	}
+
+	if err := c.prepareRemote(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Get a listing of all of the LXC containers in the environment.
+	lxcContainers, err := getLXCContainerList(&c.baseClientCommand)
+	if err != nil {
+		return errors.Annotate(err, "getting LXC container list")
+	}
+
+	doRestore := func(containerName, path string) error {
+		f, err := os.Open(path)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rc, err := runViaSSH(
+			c.address,
+			c.getRemoteCommand(c.remoteCommand, containerName),
+			withStdin(f),
+		)
+		f.Close()
+		if err != nil {
+			return errors.Annotatef(err, "running %s via SSH", c.remoteCommand)
+		}
+		if rc != 0 {
+			return errors.Errorf("restoring LXC container exited %d", rc)
+		}
+		return nil
+	}
+
+	// Restore each container matching --match,
+	// or all machines if --match isn't specified.
+	var group errgroup.Group
+	for _, container := range lxcContainers {
+		containerName := container.Id
+		if !match(containerName) {
+			ctx.Infof("Skipping non-matching container %q", containerName)
+			continue
+		}
+		path := filepath.Join(c.backupDir, container.InstanceId+".tar.xz")
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				ctx.Infof("Skipping container %q, missing backup file %q", containerName, path)
+				continue
+			}
+		}
+		ctx.Infof("Restoring container %q from %s", containerName, path)
+		if c.dryRun {
+			continue
+		}
+		group.Go(func() error {
+			return errors.Annotatef(
+				doRestore(containerName, path),
+				"restoring %q from %s",
+				containerName, path,
+			)
+		})
+	}
+	return group.Wait()
+}
+
+var restoreLXCImplDoc = `
+
+restore-lxc-impl must be executed on an API server machine of a 1.25
+environment.
+
+The command will get a list of all the LXC containers when run without
+arguments. When run with the name of a container, the command will
+SSH to the container's host, ensure the container is not running,
+stream the container's rootfs as a compressed tarball over stdin,
+unpack it, and then start the container.
+
+`
+
+func newRestoreLXCImplCommand() cmd.Command {
+	return &restoreLXCImplCommand{}
+}
+
+type restoreLXCImplCommand struct {
+	baseRemoteCommand
+	containerName string
+}
+
+func (c *restoreLXCImplCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "restore-lxc-impl",
+		Args:    "[container]",
+		Purpose: "controller aspect of restore-lxc",
+		Doc:     restoreLXCImplDoc,
+	}
+}
+
+func (c *restoreLXCImplCommand) Init(args []string) error {
+	if len(args) > 0 {
+		c.containerName, args = args[0], args[1:]
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *restoreLXCImplCommand) Run(ctx *cmd.Context) error {
+	st, err := getState()
+	if err != nil {
+		return errors.Annotate(err, "getting state")
+	}
+	defer st.Close()
+
+	if c.containerName == "" {
+		// Output a listing of LXC containers.
+		return listLXCContainers(ctx, st)
+	}
+
+	containerMachine, err := st.Machine(c.containerName)
+	if err != nil {
+		return errors.Annotate(err, "getting container machine")
+	}
+	parentId, _ := containerMachine.ParentId()
+	hostMachine, err := st.Machine(parentId)
+	if err != nil {
+		return errors.Annotate(err, "getting host machine")
+	}
+
+	logger.Debugf("restoring LXC container %q", c.containerName)
+	if err := RestoreLXCContainer(containerMachine, hostMachine, ctx.GetStdin()); err != nil {
+		return errors.Annotate(err, "restoring LXC container")
+	}
+	logger.Debugf("restarting LXC container %q", c.containerName)
+	if err := StartLXCContainer(containerMachine, hostMachine); err != nil {
+		return errors.Annotate(err, "starting LXC container")
+	}
+	return nil
+}


### PR DESCRIPTION
If you want to restore LXC containers after
migrating them, run the restore-lxc command
to put their rootfs's back in place.