### PR TITLE
Allow the lxc.hook.mount key in lxc-lxd

### DIFF
--- a/commands/lxc-to-lxd
+++ b/commands/lxc-to-lxd
@@ -32,7 +32,7 @@ keys_to_check = [
     'lxc.pivotdir',
     # 'lxc.hook.pre-start',
     # 'lxc.hook.pre-mount',
-    # 'lxc.hook.mount',
+    'lxc.hook.mount',
     # 'lxc.hook.autodev',
     # 'lxc.hook.start',
     # 'lxc.hook.stop',

--- a/commands/lxc2lxd_script.go
+++ b/commands/lxc2lxd_script.go
@@ -39,7 +39,7 @@ keys_to_check = [
     'lxc.pivotdir',
     # 'lxc.hook.pre-start',
     # 'lxc.hook.pre-mount',
-    # 'lxc.hook.mount',
+    'lxc.hook.mount',
     # 'lxc.hook.autodev',
     # 'lxc.hook.start',
     # 'lxc.hook.stop',


### PR DESCRIPTION
This is used by IS to set up static routes in containers, but only needs
to happen on first container startup. After that the configuration is
persistent in the container's ENI files.