### PR TITLE
Turn off proxy-ssh when exporting

### DIFF
--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -23,9 +23,10 @@ import (
 	version1 "github.com/juju/1.25-upgrade/juju1/version"
 )
 
-var disallowedModelConfigAttrs = [...]string{
+var removeModelConfigAttrs = [...]string{
 	"admin-secret",
 	"ca-private-key",
+	"proxy-ssh",
 }
 
 var controllerOnlyConfigAttrs = [...]string{
@@ -268,7 +269,7 @@ func (e *exporter) splitEnvironConfig() (map[string]interface{}, description.Clo
 	}
 
 	// TODO: delete all bootstrap only config values from modelConfig
-	for _, key := range disallowedModelConfigAttrs {
+	for _, key := range removeModelConfigAttrs {
 		delete(modelConfig, key)
 	}
 


### PR DESCRIPTION
This defaults to true in 1.25 but in 2 it means that juju ssh hangs. If people still need it for some reason they can turn it on after the upgrade.