### PR TITLE
Handle Openstack security groups better

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -189,7 +189,7 @@ func (c *importImplCommand) Run(ctx *cmd.Context) (err error) {
 	// We need to upgrade the tags in the environment before checking
 	// machines, since in most providers that's how we determine which
 	// instances belong to this environment/model.
-	err = upgradeTags(st)
+	err = upgradeTags(st, conn.ControllerTag().Id())
 	if err != nil {
 		return errors.Annotate(err, "upgrading environment tags")
 	}

--- a/commands/tags.go
+++ b/commands/tags.go
@@ -17,7 +17,7 @@ import (
 type TagUpgrader interface {
 	// UpgradeTags replaces juju-env-uuid tags with juju-model-uuid on
 	// any resources that need updating.
-	UpgradeTags() error
+	UpgradeTags(controllerUUID string) error
 	// Downgrade tags converts juju-model-uuid tags back to
 	// juju-env-uuid, and removes any juju-controller-uuid tags.
 	DowngradeTags() error
@@ -43,12 +43,12 @@ func getTagUpgrader(st *state.State) (TagUpgrader, error) {
 	return upgrader, nil
 }
 
-func upgradeTags(st *state.State) error {
+func upgradeTags(st *state.State, controllerUUID string) error {
 	upgrader, err := getTagUpgrader(st)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return upgrader.UpgradeTags()
+	return upgrader.UpgradeTags(controllerUUID)
 }
 
 func downgradeTags(st *state.State) error {


### PR DESCRIPTION
Tagging was wrong for Openstack - we needed to update security groups as well so that they have the right names. Work around a deficiency in the nova-firewaller code in the target controller's Openstack provider when we call AdoptResources.