### PR TITLE
Update group deletion to work with controller UUID

### DIFF
--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -1317,10 +1317,15 @@ func (e *exporter) statusArgs(globalKey string) (description.StatusArgs, error) 
 	return result, nil
 }
 
+const maxStatusHistoryEntries = 20
+
 func (e *exporter) statusHistoryArgs(globalKey string) []description.StatusArgs {
 	history := e.statusHistory[globalKey]
 	result := make([]description.StatusArgs, len(history))
 	e.logger.Debugf("found %d status history docs for %s", len(history), globalKey)
+	if len(history) > maxStatusHistoryEntries {
+		history = history[:maxStatusHistoryEntries]
+	}
 	for i, doc := range history {
 		result[i] = description.StatusArgs{
 			Value:   string(doc.Status),


### PR DESCRIPTION
The workaround for the problem with AdoptResources means that security
groups that need to be deleted now are named
juju-<controlleruuid>-<modeluuid>-0, so handle that in the downgrade
step. Also remove the groups from any instances before trying to delete
them.

Includes a small tweak to limit status history migrated to 20 items.