### PR TITLE
Rename LXC containers to LXD during upgrade

### DIFF
--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -10,6 +10,7 @@ import json
 import os
 from os import path
 import shutil
+import subprocess
 import sys
 import tarfile
 import yaml
@@ -25,8 +26,13 @@ API_ADDRESSES = """{{range .ControllerInfo.Addrs}}{{.}}
 
 BASE_DIR = '/var/lib/juju'
 ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
+ROLLBACK_INIT_DIR = path.join(ROLLBACK_DIR, 'init')
 TOOLS_DIR = path.join(BASE_DIR, 'tools')
 AGENTS_DIR = path.join(BASE_DIR, 'agents')
+INIT_DIR = path.join(BASE_DIR, 'init')
+
+UPSTART_DIR = '/etc/init'
+SYSTEMD_DIR = '/etc/systemd/system'
 
 UPGRADE_DIR, SCRIPT = path.split(__file__)
 
@@ -102,7 +108,8 @@ def convert_lxd_agent(agent):
     return convert_container_agent(agent, 'lxd', 'lxc')
 
 def save_rollback_info():
-    os.mkdir(ROLLBACK_DIR)
+    os.makedirs(ROLLBACK_INIT_DIR)
+    series = get_series()
     for agent in all_agents():
         tools_link = path.join(TOOLS_DIR, agent)
         target = os.readlink(tools_link)
@@ -111,6 +118,22 @@ def save_rollback_info():
         agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(agent_conf, backup_path)
+
+        if series == 'trusty':
+            agent_init = path.join(UPSTART_DIR, upstart_conf(agent))
+            shutil.copy(agent_init, ROLLBACK_INIT_DIR)
+        else:
+            # Grab the service symlink...
+            service = systemd_conf(agent)
+            init_link = path.join(SYSTEMD_DIR, service)
+            target = os.readlink(init_link)
+            os.symlink(target, path.join(ROLLBACK_INIT_DIR, service))
+
+            # ...And the init subdir.
+            dirname = 'jujud-' + agent
+            agent_init_dir = path.join(INIT_DIR, dirname)
+            saved_dir = path.join(ROLLBACK_INIT_DIR, dirname)
+            shutil.copytree(agent_init_dir, saved_dir)
 
 def find_new_tools():
     files = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
@@ -144,9 +167,7 @@ def install_tools():
 def make_links(in_dir, names, target):
     for name in names:
         link_path = path.join(in_dir, name)
-        if path.exists(link_path):
-            os.unlink(link_path)
-        os.symlink(target, link_path)
+        force_symlink(target, link_path)
 
 def update_configs():
     for agent in all_agents():
@@ -202,14 +223,69 @@ def update_unit_config(agent, data):
 
     return data
 
+def get_series():
+    return subprocess.check_output(['/usr/bin/lsb_release', '-cs']).decode().strip()
+
 def main():
     assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'
     save_rollback_info()
     install_tools()
     update_configs()
 
+def safe_unlink(location):
+    if path.exists(location):
+        os.unlink(location)
+
+def force_symlink(target, dest):
+    safe_unlink(dest)
+    os.symlink(target, dest)
+
+def upstart_conf(agent):
+    return 'jujud-{}.conf'.format(agent)
+
+def systemd_conf(agent):
+    return 'jujud-{}.service'.format(agent)
+
+def rollback_upstart(lxd_agent, lxc_agent):
+    safe_unlink(path.join(UPSTART_DIR, upstart_conf(lxd_agent)))
+    saved_conf = path.join(ROLLBACK_INIT_DIR, upstart_conf(lxc_agent))
+    shutil.copy(saved_conf, UPSTART_DIR)
+
+def rollback_systemd(lxd_agent, lxc_agent):
+    # Get rid of any lxd version of the agent files under /var/lib/juju/init.
+    lxd_init_dir = path.join(INIT_DIR, 'jujud-' + lxd_agent)
+    if path.exists(lxd_init_dir):
+        shutil.rmtree(lxd_init_dir)
+
+    # Reinstate the lxc init files.
+    lxc_init_dir = path.join(INIT_DIR, 'jujud-' + lxc_agent)
+    if path.exists(lxc_init_dir):
+        shutil.rmtree(lxc_init_dir)
+    shutil.copytree(path.join(ROLLBACK_INIT_DIR, 'jujud-' + lxc_agent), lxc_init_dir)
+
+    # Get rid of any lxd symlink from /etc/systemd/system.
+    safe_unlink(path.join(SYSTEMD_DIR, systemd_conf(lxd_agent)))
+    # Reinstate the lxc link.
+    lxc_agent_conf = systemd_conf(lxc_agent)
+    force_symlink(path.join(lxc_init_dir, lxc_agent_conf), path.join(SYSTEMD_DIR, lxc_agent_conf))
+
+def rollback_init_files(series, lxd_agent, lxc_agent):
+    if series == 'trusty':
+        rollback_upstart(lxd_agent, lxc_agent)
+    else:
+        rollback_systemd(lxd_agent, lxc_agent)
+
+def reload_init(series):
+    if series == 'trusty':
+        command = ['/sbin/initctl', 'reload']
+    else:
+        command = ['/bin/systemctl', 'daemon-reload']
+    subprocess.check_call(command)
+
 def rollback():
     assert path.exists(ROLLBACK_DIR), 'no rollback information found'
+    series = get_series()
+    need_init_reload = False
     for agent in all_agents():
         lxd, lxc_agent = convert_lxd_agent(agent)
         if lxd:
@@ -218,17 +294,16 @@ def rollback():
             os.rename(
                 path.join(AGENTS_DIR, agent),
                 path.join(AGENTS_DIR, lxc_agent))
-            lxd_tools_link = path.join(TOOLS_DIR, agent)
-            if path.exists(lxd_tools_link):
-                os.unlink(lxd_tools_link)
+            safe_unlink(path.join(TOOLS_DIR, agent))
+
+            rollback_init_files(series, agent, lxc_agent)
+            need_init_reload = True
             agent = lxc_agent
 
         link_path = path.join(ROLLBACK_DIR, agent)
         target = os.readlink(link_path)
         dest = path.join(TOOLS_DIR, agent)
-        if path.exists(dest):
-            os.unlink(dest)
-        os.symlink(target, dest)
+        force_symlink(target, dest)
 
         agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
@@ -238,6 +313,9 @@ def rollback():
     added_tools = path.join(TOOLS_DIR, tools_base)
     shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
+
+    if need_init_reload:
+        reload_init(series)
 
 if __name__ == "__main__":
     if len(sys.argv) == 2 and sys.argv[1] == "rollback":

--- a/commands/agent-upgrade.py
+++ b/commands/agent-upgrade.py
@@ -170,10 +170,14 @@ def make_links(in_dir, names, target):
         force_symlink(target, link_path)
 
 def update_configs():
+    series = get_series()
+    need_init_reload = False
     for agent in all_agents():
         lxc, lxd_agent = convert_lxc_agent(agent)
         if lxc:
             os.rename(path.join(AGENTS_DIR, agent), path.join(AGENTS_DIR, lxd_agent))
+            update_init_scripts(series, agent, lxd_agent)
+            need_init_reload = True
             agent = lxd_agent
         data = read_agent_config(agent)
         if agent.startswith('machine-'):
@@ -181,6 +185,8 @@ def update_configs():
         else:
             data = update_unit_config(agent, data)
         write_agent_config(agent, data)
+    if need_init_reload:
+        reload_init(series)
 
 def config_path(agent):
     return path.join(AGENTS_DIR, agent, 'agent.conf')
@@ -223,6 +229,46 @@ def update_unit_config(agent, data):
 
     return data
 
+def update_init_scripts(series, lxc_agent, lxd_agent):
+    if series == 'trusty':
+        update_upstart_scripts(lxc_agent, lxd_agent)
+    else:
+        update_systemd_scripts(lxc_agent, lxd_agent)
+
+def update_upstart_scripts(lxc_agent, lxd_agent):
+    lxc_path = path.join(UPSTART_DIR, upstart_conf(lxc_agent))
+    lxd_path = path.join(UPSTART_DIR, upstart_conf(lxd_agent))
+    rewrite_lxc_to_lxd(lxc_path, lxd_path)
+    safe_unlink(lxc_path)
+
+def rewrite_lxc_to_lxd(lxc_path, lxd_path):
+    "Copies contents of lxc_path file into lxd_path, converting lxc->lxd on the way"
+    with open(lxc_path, 'r') as source:
+        data = source.read()
+    updated = data.replace('lxc', 'lxd')
+    with open(lxd_path, 'w') as dest:
+        dest.write(updated)
+
+def update_systemd_scripts(lxc_agent, lxd_agent):
+    lxc_dir = path.join(INIT_DIR, 'jujud-' + lxc_agent)
+    lxd_dir = path.join(INIT_DIR, 'jujud-' + lxd_agent)
+
+    # Create lxd versions of service file and exec-start script.
+    os.mkdir(lxd_dir)
+    lxd_service_path = path.join(lxd_dir, systemd_conf(lxd_agent))
+    rewrite_lxc_to_lxd(
+        path.join(lxc_dir, systemd_conf(lxc_agent)),
+        lxd_service_path)
+    lxd_exec_start = path.join(lxd_dir, 'exec-start.sh')
+    rewrite_lxc_to_lxd(path.join(lxc_dir, 'exec-start.sh'), lxd_exec_start)
+    os.chmod(lxd_exec_start, 0o755)
+
+    shutil.rmtree(lxc_dir)
+
+    # Correct the link from /etc/systemd/system
+    os.unlink(path.join(SYSTEMD_DIR, systemd_conf(lxc_agent)))
+    force_symlink(lxd_service_path, path.join(SYSTEMD_DIR, systemd_conf(lxd_agent)))
+
 def get_series():
     return subprocess.check_output(['/usr/bin/lsb_release', '-cs']).decode().strip()
 
@@ -233,7 +279,8 @@ def main():
     update_configs()
 
 def safe_unlink(location):
-    if path.exists(location):
+    # path.exists returns False for broken symlinks.
+    if path.exists(location) or path.islink(location):
         os.unlink(location)
 
 def force_symlink(target, dest):
@@ -277,7 +324,7 @@ def rollback_init_files(series, lxd_agent, lxc_agent):
 
 def reload_init(series):
     if series == 'trusty':
-        command = ['/sbin/initctl', 'reload']
+        command = ['/sbin/initctl', 'reload-configuration']
     else:
         command = ['/bin/systemctl', 'daemon-reload']
     subprocess.check_call(command)

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -17,6 +17,7 @@ import json
 import os
 from os import path
 import shutil
+import subprocess
 import sys
 import tarfile
 import yaml
@@ -32,8 +33,13 @@ API_ADDRESSES = """{{range .ControllerInfo.Addrs}}{{.}}
 
 BASE_DIR = '/var/lib/juju'
 ROLLBACK_DIR = path.join(BASE_DIR, '1.25-upgrade-rollback')
+ROLLBACK_INIT_DIR = path.join(ROLLBACK_DIR, 'init')
 TOOLS_DIR = path.join(BASE_DIR, 'tools')
 AGENTS_DIR = path.join(BASE_DIR, 'agents')
+INIT_DIR = path.join(BASE_DIR, 'init')
+
+UPSTART_DIR = '/etc/init'
+SYSTEMD_DIR = '/etc/systemd/system'
 
 UPGRADE_DIR, SCRIPT = path.split(__file__)
 
@@ -109,7 +115,8 @@ def convert_lxd_agent(agent):
     return convert_container_agent(agent, 'lxd', 'lxc')
 
 def save_rollback_info():
-    os.mkdir(ROLLBACK_DIR)
+    os.makedirs(ROLLBACK_INIT_DIR)
+    series = get_series()
     for agent in all_agents():
         tools_link = path.join(TOOLS_DIR, agent)
         target = os.readlink(tools_link)
@@ -118,6 +125,22 @@ def save_rollback_info():
         agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
         shutil.copy(agent_conf, backup_path)
+
+        if series == 'trusty':
+            agent_init = path.join(UPSTART_DIR, upstart_conf(agent))
+            shutil.copy(agent_init, ROLLBACK_INIT_DIR)
+        else:
+            # Grab the service symlink...
+            service = systemd_conf(agent)
+            init_link = path.join(SYSTEMD_DIR, service)
+            target = os.readlink(init_link)
+            os.symlink(target, path.join(ROLLBACK_INIT_DIR, service))
+
+            # ...And the init subdir.
+            dirname = 'jujud-' + agent
+            agent_init_dir = path.join(INIT_DIR, dirname)
+            saved_dir = path.join(ROLLBACK_INIT_DIR, dirname)
+            shutil.copytree(agent_init_dir, saved_dir)
 
 def find_new_tools():
     files = [name for name in os.listdir(UPGRADE_DIR) if path.join(UPGRADE_DIR, name).endswith('.tgz')]
@@ -151,9 +174,7 @@ def install_tools():
 def make_links(in_dir, names, target):
     for name in names:
         link_path = path.join(in_dir, name)
-        if path.exists(link_path):
-            os.unlink(link_path)
-        os.symlink(target, link_path)
+        force_symlink(target, link_path)
 
 def update_configs():
     for agent in all_agents():
@@ -209,14 +230,69 @@ def update_unit_config(agent, data):
 
     return data
 
+def get_series():
+    return subprocess.check_output(['/usr/bin/lsb_release', '-cs']).decode().strip()
+
 def main():
     assert not path.exists(ROLLBACK_DIR), 'saved rollback information found - aborting'
     save_rollback_info()
     install_tools()
     update_configs()
 
+def safe_unlink(location):
+    if path.exists(location):
+        os.unlink(location)
+
+def force_symlink(target, dest):
+    safe_unlink(dest)
+    os.symlink(target, dest)
+
+def upstart_conf(agent):
+    return 'jujud-{}.conf'.format(agent)
+
+def systemd_conf(agent):
+    return 'jujud-{}.service'.format(agent)
+
+def rollback_upstart(lxd_agent, lxc_agent):
+    safe_unlink(path.join(UPSTART_DIR, upstart_conf(lxd_agent)))
+    saved_conf = path.join(ROLLBACK_INIT_DIR, upstart_conf(lxc_agent))
+    shutil.copy(saved_conf, UPSTART_DIR)
+
+def rollback_systemd(lxd_agent, lxc_agent):
+    # Get rid of any lxd version of the agent files under /var/lib/juju/init.
+    lxd_init_dir = path.join(INIT_DIR, 'jujud-' + lxd_agent)
+    if path.exists(lxd_init_dir):
+        shutil.rmtree(lxd_init_dir)
+
+    # Reinstate the lxc init files.
+    lxc_init_dir = path.join(INIT_DIR, 'jujud-' + lxc_agent)
+    if path.exists(lxc_init_dir):
+        shutil.rmtree(lxc_init_dir)
+    shutil.copytree(path.join(ROLLBACK_INIT_DIR, 'jujud-' + lxc_agent), lxc_init_dir)
+
+    # Get rid of any lxd symlink from /etc/systemd/system.
+    safe_unlink(path.join(SYSTEMD_DIR, systemd_conf(lxd_agent)))
+    # Reinstate the lxc link.
+    lxc_agent_conf = systemd_conf(lxc_agent)
+    force_symlink(path.join(lxc_init_dir, lxc_agent_conf), path.join(SYSTEMD_DIR, lxc_agent_conf))
+
+def rollback_init_files(series, lxd_agent, lxc_agent):
+    if series == 'trusty':
+        rollback_upstart(lxd_agent, lxc_agent)
+    else:
+        rollback_systemd(lxd_agent, lxc_agent)
+
+def reload_init(series):
+    if series == 'trusty':
+        command = ['/sbin/initctl', 'reload']
+    else:
+        command = ['/bin/systemctl', 'daemon-reload']
+    subprocess.check_call(command)
+
 def rollback():
     assert path.exists(ROLLBACK_DIR), 'no rollback information found'
+    series = get_series()
+    need_init_reload = False
     for agent in all_agents():
         lxd, lxc_agent = convert_lxd_agent(agent)
         if lxd:
@@ -225,17 +301,16 @@ def rollback():
             os.rename(
                 path.join(AGENTS_DIR, agent),
                 path.join(AGENTS_DIR, lxc_agent))
-            lxd_tools_link = path.join(TOOLS_DIR, agent)
-            if path.exists(lxd_tools_link):
-                os.unlink(lxd_tools_link)
+            safe_unlink(path.join(TOOLS_DIR, agent))
+
+            rollback_init_files(series, agent, lxc_agent)
+            need_init_reload = True
             agent = lxc_agent
 
         link_path = path.join(ROLLBACK_DIR, agent)
         target = os.readlink(link_path)
         dest = path.join(TOOLS_DIR, agent)
-        if path.exists(dest):
-            os.unlink(dest)
-        os.symlink(target, dest)
+        force_symlink(target, dest)
 
         agent_conf = path.join(AGENTS_DIR, agent, 'agent.conf')
         backup_path = path.join(ROLLBACK_DIR, agent + '_agent.conf')
@@ -245,6 +320,9 @@ def rollback():
     added_tools = path.join(TOOLS_DIR, tools_base)
     shutil.rmtree(added_tools)
     shutil.rmtree(ROLLBACK_DIR)
+
+    if need_init_reload:
+        reload_init(series)
 
 if __name__ == "__main__":
     if len(sys.argv) == 2 and sys.argv[1] == "rollback":

--- a/commands/agentupgrade_script.go
+++ b/commands/agentupgrade_script.go
@@ -91,6 +91,23 @@ yaml.add_representer(Literal, literal_presenter)
 def all_agents():
     return os.listdir(AGENTS_DIR)
 
+def convert_container_agent(agent, from_type, to_type):
+    parts = agent.split('-')
+    match = False
+    output = []
+    for part in parts:
+        if part == from_type:
+            match = True
+            part = to_type
+        output.append(part)
+    return match, '-'.join(output)
+
+def convert_lxc_agent(agent):
+    return convert_container_agent(agent, 'lxc', 'lxd')
+
+def convert_lxd_agent(agent):
+    return convert_container_agent(agent, 'lxd', 'lxc')
+
 def save_rollback_info():
     os.mkdir(ROLLBACK_DIR)
     for agent in all_agents():
@@ -129,7 +146,7 @@ def install_tools():
     # Make all the hook tools link to jujud.
     make_links(dest_path, HOOK_TOOLS, path.join(dest_path, 'jujud'))
     # Make all of the agent tools dirs link to the new version.
-    make_links(TOOLS_DIR, all_agents(), dest_path)
+    make_links(TOOLS_DIR, [convert_lxc_agent(a)[1] for a in all_agents()], dest_path)
 
 def make_links(in_dir, names, target):
     for name in names:
@@ -140,6 +157,10 @@ def make_links(in_dir, names, target):
 
 def update_configs():
     for agent in all_agents():
+        lxc, lxd_agent = convert_lxc_agent(agent)
+        if lxc:
+            os.rename(path.join(AGENTS_DIR, agent), path.join(AGENTS_DIR, lxd_agent))
+            agent = lxd_agent
         data = read_agent_config(agent)
         if agent.startswith('machine-'):
             data = update_machine_config(agent, data)
@@ -167,6 +188,8 @@ def update_machine_config(agent, data):
     for name in OLD_CONTROLLER_KEYS:
         if name in data:
             del data[name]
+    # Convert any lxc agent tags to lxd
+    data['tag'] = convert_lxc_agent(data['tag'])[1]
     return update_unit_config(agent, data)
 
 def update_unit_config(agent, data):
@@ -195,6 +218,18 @@ def main():
 def rollback():
     assert path.exists(ROLLBACK_DIR), 'no rollback information found'
     for agent in all_agents():
+        lxd, lxc_agent = convert_lxd_agent(agent)
+        if lxd:
+            # We need to rename the agent dir and get rid of the tools
+            # link for the lxd version of the agent.
+            os.rename(
+                path.join(AGENTS_DIR, agent),
+                path.join(AGENTS_DIR, lxc_agent))
+            lxd_tools_link = path.join(TOOLS_DIR, agent)
+            if path.exists(lxd_tools_link):
+                os.unlink(lxd_tools_link)
+            agent = lxc_agent
+
         link_path = path.join(ROLLBACK_DIR, agent)
         target = os.readlink(link_path)
         dest = path.join(TOOLS_DIR, agent)

--- a/commands/migratelxc.go
+++ b/commands/migratelxc.go
@@ -196,7 +196,7 @@ func (c *migrateLXCImplCommand) Run(ctx *cmd.Context) error {
 	}
 	if err := waitLXDContainersReady(
 		lxcByHost, containerNames,
-		time.Minute, // should be long enough for anyone
+		5*time.Minute, // should be long enough for anyone
 	); err != nil {
 		return errors.Annotate(err, "waiting for LXD containers to have addresses")
 	}
@@ -298,7 +298,8 @@ func getContainerNames(
 
 			// The new name, expected by Juju 2.x, uses a model
 			// UUID namespace.
-			newName, err := namespace.Hostname(container.Id())
+			newName, err := namespace.Hostname(strings.Replace(
+				container.Id(), "lxc", "lxd", 1))
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
They were converted to LXD but still named things like `3/lxc/4`.
This requires changing a number of places:
* renaming the machines in the exported model (in `import`)
* renaming the containers in LXD (`migrate-lxc`)
* renaming the machine agents in on-machine config and tools (`upgrade-agents`)
* rewriting the init scripts to keep the machine agents running (for `start-agents`, but done in `upgrade-agents`)
