### PR TITLE
Exclude invalid relation units from export

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -23,7 +23,7 @@ github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	7725027b95e0d54635e0fb11efc2debdcdf19f75	2016-12-15T16:06:52Z
 github.com/juju/cmd	git	0f05ac592d6925a1b8ca0f77524d3348fafa66cc	2017-02-07T03:13:09Z
-github.com/juju/description	git	b764a15740dbcb800ec894fedd41cc0a37826419	2017-07-06T03:32:20Z
+github.com/juju/description	git	264ae46133b5a24cfc4f55717d4ed83bb2983b8f	2017-08-09T23:16:08Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gnuflag	git	4e76c56581859c14d9d87e1ddbe29e1c0f10195f	2016-08-09T16:52:14Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z

--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -990,6 +990,19 @@ func (e *exporter) relations() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
+				// Logic for skipping invalid relation units ported
+				// back from juju2.
+				valid, err := ru.Valid()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if !valid {
+					// It doesn't make sense for this application to have a
+					// relations scope for this endpoint. For example the
+					// situation where we have a subordinate charm related to
+					// two different principals.
+					continue
+				}
 				key := ru.currentKey()
 				if !relationScopes.Contains(key) {
 					return errors.Errorf("missing relation scope for %s and %s", relation, unit.Name())

--- a/juju1/state/relation.go
+++ b/juju1/state/relation.go
@@ -243,7 +243,7 @@ func (r *Relation) Endpoint(serviceName string) (Endpoint, error) {
 			return ep, nil
 		}
 	}
-	return Endpoint{}, fmt.Errorf("service %q is not a member of %q", serviceName, r)
+	return Endpoint{}, errors.NotFoundf("service %q is not a member of %q", serviceName, r)
 }
 
 // Endpoints returns the endpoints for the relation.

--- a/juju1/state/relationunit.go
+++ b/juju1/state/relationunit.go
@@ -354,6 +354,62 @@ func (ru *RelationUnit) LeaveScope() error {
 	return nil
 }
 
+// Valid returns whether this RelationUnit is one that can actually
+// exist in the relation. For container-scoped relations, RUs can be
+// created for subordinate units whose principal unit isn't a member
+// of the relation. There are too many places that rely on being able
+// to construct a nonsensical RU to query InScope or Joined, so we
+// allow them to be constructed but they will always return false for
+// Valid.
+// Ported back from juju2 for use in export.
+func (ru *RelationUnit) Valid() (bool, error) {
+	if ru.endpoint.Scope != charm.ScopeContainer || ru.unit.IsPrincipal() {
+		return true, nil
+	}
+	// A subordinate container-scoped relation unit is valid if:
+	// the other end of the relation is also a subordinate charm
+	// or its principal unit is also a member of the relation.
+	appName, err := names.UnitService(ru.unit.Name())
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	var otherAppName string
+	for _, ep := range ru.relation.Endpoints() {
+		if ep.ServiceName != appName {
+			otherAppName = ep.ServiceName
+		}
+	}
+	if otherAppName == "" {
+		return false, errors.Errorf("couldn't find other endpoint")
+	}
+	otherApp, err := ru.st.Service(otherAppName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if !otherApp.IsPrincipal() {
+		return true, nil
+	}
+
+	unit, err := ru.st.Unit(ru.unit.Name())
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	// No need to check the flag here - we know we're subordinate.
+	pName, _ := unit.PrincipalName()
+	principalAppName, err := names.UnitService(pName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	// If the other application is a principal, only allow it if it's in the relation.
+	_, err = ru.relation.Endpoint(principalAppName)
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}
+
 // InScope returns whether the relation unit has entered scope and not left it.
 func (ru *RelationUnit) InScope() (bool, error) {
 	return ru.inScope(nil)


### PR DESCRIPTION
If there's a subordinate application related to multiple principal apps,
in Juju 1.25 there'll be relation scopes for units that shouldn't be
involved in the relation - eg:

ubuntu/0
  telegraf/0
ntpmaster/0
  telegraf/1

There'll be a relation scope for telegraf/1 for the ubuntu-telegraf
relation. Exclude this from the export, since in Juju 2.2.3 it wouldn't
be there, and things get a bit confused if it is.

Ported this change back from Juju 2.2.3.
Updates the description dependency.