### PR TITLE
Correct status history truncation

### DIFF
--- a/juju1/state/migration_export.go
+++ b/juju1/state/migration_export.go
@@ -1371,11 +1371,11 @@ const maxStatusHistoryEntries = 20
 
 func (e *exporter) statusHistoryArgs(globalKey string) []description.StatusArgs {
 	history := e.statusHistory[globalKey]
-	result := make([]description.StatusArgs, len(history))
 	e.logger.Debugf("found %d status history docs for %s", len(history), globalKey)
 	if len(history) > maxStatusHistoryEntries {
 		history = history[:maxStatusHistoryEntries]
 	}
+	result := make([]description.StatusArgs, len(history))
 	for i, doc := range history {
 		result[i] = description.StatusArgs{
 			Value:   string(doc.Status),


### PR DESCRIPTION
It was chopping off the history but the result slice was created based
on the original length, so the export ended up containing lots of empty
status records.