### PR TITLE
Add revert-lxd command to roll migrated containers back to LXC

### DIFF
--- a/commands/lxc2lxd.go
+++ b/commands/lxc2lxd.go
@@ -122,6 +122,27 @@ func StopLXCContainer(container, host *state.Machine) error {
 	return nil
 }
 
+// StopLXDContainer stops the specified LXD container on the host
+// machine.
+func StopLXDContainer(name string, host *state.Machine) error {
+	hostAddr, err := getMachineAddress(host)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rc, err := runViaSSH(
+		hostAddr,
+		"lxc stop "+name,
+		withSystemIdentity(),
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if rc != 0 {
+		return errors.Errorf("`lxc stop` exited %d", rc)
+	}
+	return nil
+}
+
 // StartLXCContainer starts the specified LXC container machine.
 func StartLXCContainer(container, host *state.Machine) error {
 	hostAddr, err := getMachineAddress(host)

--- a/commands/main.go
+++ b/commands/main.go
@@ -63,4 +63,6 @@ func registerCommands(super *cmd.SuperCommand) {
 	super.Register(newImportImplCommand())
 	super.Register(newActivateCommand())
 	super.Register(newActivateImplCommand())
+	super.Register(newRevertLXDCommand())
+	super.Register(newRevertLXDImplCommand())
 }

--- a/commands/migratelxc.go
+++ b/commands/migratelxc.go
@@ -563,11 +563,11 @@ func waitContainerReady(ctx context.Context, containerName, containerAddr, hostA
 func stopContainerAgents(
 	ctx *cmd.Context,
 	st *state.State,
-	lxcByHost map[*state.Machine][]*state.Machine,
+	containersByHost map[*state.Machine][]*state.Machine,
 ) error {
 	// Stop the Juju agents on the containers.
 	var flatMachines []FlatMachine
-	for _, containers := range lxcByHost {
+	for _, containers := range containersByHost {
 		for _, container := range containers {
 			fm, err := makeFlatMachine(st, container)
 			if err != nil {

--- a/commands/migratelxc.go
+++ b/commands/migratelxc.go
@@ -27,10 +27,10 @@ LXC containers in a 1.25 environment to LXD.
 
 If --match is specified, it is treated as a regular expression for
 matching container names. Only containers whose names match will
-be backed up.
+be migrated.
 
-If --dry-run is specified, then no backups will be created, nor
-will the containers be stopped.
+If --dry-run is specified, then no migration will actually be
+performed, nor will the containers be stopped.
 `
 
 func newMigrateLXCCommand() cmd.Command {
@@ -194,13 +194,13 @@ func (c *migrateLXCImplCommand) Run(ctx *cmd.Context) error {
 	if err := startLXDContainers(lxcByHost, lxdByHost, containerNames); err != nil {
 		return errors.Annotate(err, "starting LXD containers")
 	}
-	if err := waitLXDContainersReady(
-		lxcByHost, containerNames,
+	if err := waitContainersReady(
+		"lxd", lxcByHost, containerNames,
 		5*time.Minute, // should be long enough for anyone
 	); err != nil {
 		return errors.Annotate(err, "waiting for LXD containers to have addresses")
 	}
-	if err := stopLXDContainerAgents(ctx, st, lxcByHost); err != nil {
+	if err := stopContainerAgents(ctx, st, lxcByHost); err != nil {
 		return errors.Annotate(err, "stopping Juju agents in LXD containers")
 	}
 
@@ -492,10 +492,11 @@ func startLXDContainers(
 	return group.Wait()
 }
 
-// waitLXDContainersReady waits for the LXD containers to have
-// addresses, as recorded in the state database, and be ready to
-// accept SSH connections.
-func waitLXDContainersReady(
+// waitContainersReady waits for the containers to have addresses, as
+// recorded in the state database, and be ready to accept SSH
+// connections.
+func waitContainersReady(
+	containerType string,
 	lxcByHost map[*state.Machine][]*state.Machine,
 	containerNames map[*state.Machine]containerNames,
 	timeout time.Duration,
@@ -504,7 +505,7 @@ func waitLXDContainersReady(
 	defer cancel()
 	group, ctx := errgroup.WithContext(ctx)
 
-	logger.Debugf("waiting for LXD containers to be ready for SSH connections")
+	logger.Debugf("waiting for %s containers to be ready for SSH connections", containerType)
 	for host, containers := range lxcByHost {
 		hostAddr, err := getMachineAddress(host)
 		if err != nil {
@@ -515,10 +516,15 @@ func waitLXDContainersReady(
 			if err != nil {
 				return errors.Trace(err)
 			}
-			containerName := containerNames[container].newName
+			var containerName string
+			if containerType == "lxd" {
+				containerName = containerNames[container].newName
+			} else {
+				containerName = containerNames[container].oldName
+			}
 			group.Go(func() error {
 				return errors.Annotatef(
-					waitLXDContainerReady(ctx, containerName, containerAddr, hostAddr),
+					waitContainerReady(ctx, containerName, containerAddr, hostAddr),
 					"waiting for %q to be ready for SSH connections",
 					containerName,
 				)
@@ -528,7 +534,7 @@ func waitLXDContainersReady(
 	return group.Wait()
 }
 
-func waitLXDContainerReady(ctx context.Context, containerName, containerAddr, hostAddr string) error {
+func waitContainerReady(ctx context.Context, containerName, containerAddr, hostAddr string) error {
 	const interval = time.Second // time to wait between checks
 	for {
 		logger.Debugf(
@@ -552,14 +558,14 @@ func waitLXDContainerReady(ctx context.Context, containerName, containerAddr, ho
 	}
 }
 
-// stopLXDContainerAgents stops the Juju agents running inside
-// LXD containers. The LXD containers are expected to be running.
-func stopLXDContainerAgents(
+// stopContainerAgents stops the Juju agents running inside
+// LXC or LXD containers. The containers are expected to be running.
+func stopContainerAgents(
 	ctx *cmd.Context,
 	st *state.State,
 	lxcByHost map[*state.Machine][]*state.Machine,
 ) error {
-	// Stop the Juju agents on the LXD containers.
+	// Stop the Juju agents on the containers.
 	var flatMachines []FlatMachine
 	for _, containers := range lxcByHost {
 		for _, container := range containers {
@@ -571,7 +577,7 @@ func stopLXDContainerAgents(
 		}
 	}
 
-	logger.Debugf("stopping Juju agents running in LXD machines")
+	logger.Debugf("stopping Juju agents running in container machines")
 	_, err := agentServiceCommand(ctx, flatMachines, "stop")
 	return errors.Trace(err)
 }

--- a/commands/revertlxd.go
+++ b/commands/revertlxd.go
@@ -1,0 +1,364 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/juju/1.25-upgrade/juju1/state"
+)
+
+var revertLXDDoc = `
+The revert-lxd command reverts migrated LXD containers back to LXC as
+part of aborting a 1.25 upgrade.
+
+If --match is specified, it is treated as a regular expression for
+matching container names. Only containers whose original (unmigrated)
+names match will be reverted.
+
+This command requires information from the source environment state
+database, so it will only work after running the abort command if
+upgrade-agents has been run.
+`
+
+func newRevertLXDCommand() cmd.Command {
+	command := &revertLXDCommand{}
+	command.remoteCommand = "revert-lxd-impl"
+	return wrap(command)
+}
+
+type revertLXDCommand struct {
+	baseClientCommand
+	match string
+}
+
+func (c *revertLXDCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "revert-lxd",
+		Args:    "<environment name>",
+		Purpose: "revert migrated LXD containers back to LXC",
+		Doc:     revertLXDDoc,
+	}
+}
+
+func (c *revertLXDCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.baseClientCommand.SetFlags(f)
+	f.StringVar(&c.match, "match", "", "regular expression for matching LXD container IDs to revert")
+}
+
+func (c *revertLXDCommand) Init(args []string) error {
+	args, err := c.baseClientCommand.init(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *revertLXDCommand) Run(ctx *cmd.Context) error {
+	if c.match != "" {
+		c.extraOptions = append(c.extraOptions, utils.ShQuote("--match="+c.match))
+	}
+	return c.baseClientCommand.Run(ctx)
+}
+
+var revertLXDImplDoc = `
+
+revert-lxd-impl must be executed on an API server machine of a 1.25
+environment.
+
+The command will revert matching migrated LXD containers in the
+environment back to LXC.
+
+`
+
+func newRevertLXDImplCommand() cmd.Command {
+	return &revertLXDImplCommand{}
+}
+
+type revertLXDImplCommand struct {
+	baseRemoteCommand
+	match string
+}
+
+func (c *revertLXDImplCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "revert-lxd-impl",
+		Purpose: "controller aspect of revert-lxd",
+		Doc:     revertLXDImplDoc,
+	}
+}
+
+func (c *revertLXDImplCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.baseRemoteCommand.SetFlags(f)
+	f.StringVar(&c.match, "match", "", "regular expression for matching LXD container IDs to revert")
+}
+
+func (c *revertLXDImplCommand) Run(ctx *cmd.Context) error {
+	match := func(string) bool { return true }
+	if c.match != "" {
+		matchRE, err := regexp.Compile(c.match)
+		if err != nil {
+			return errors.Annotate(err, "parsing --match")
+		}
+		match = matchRE.MatchString
+	}
+
+	st, err := getState()
+	if err != nil {
+		return errors.Annotate(err, "getting state")
+	}
+	defer st.Close()
+
+	// Collect LXC container machines by host.
+	lxcByHost, err := getLXCContainersFromState(st)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for host, containers := range lxcByHost {
+		matching := make([]*state.Machine, 0, len(containers))
+		for _, container := range containers {
+			if !match(container.Id()) {
+				ctx.Infof("Skipping non-matching container %q", container.Id())
+				continue
+			}
+			matching = append(matching, container)
+		}
+		if len(matching) == 0 {
+			delete(lxcByHost, host)
+			continue
+		}
+		lxcByHost[host] = matching
+	}
+
+	environUUID := st.EnvironUUID()
+	containerNames, err := getContainerNames(lxcByHost, environUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// List LXD containers on each host, so we know which containers
+	// still need reverting. This is required to make the revert-lxd
+	// command idempotent/resumable.
+	hosts := make([]*state.Machine, 0, len(lxcByHost))
+	for host := range lxcByHost {
+		hosts = append(hosts, host)
+	}
+	lxdByHost, err := getLXDContainersFromMachines(hosts)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Determine which LXD containers still need to be reverted,
+	// by looking for LXD containers of the same (or new) names.
+	lxdToRevertByHost := getAllLXDContainersToRevert(
+		ctx, lxcByHost, lxdByHost, containerNames,
+	)
+
+	if err := stopLXDContainers(lxdToRevertByHost); err != nil {
+		return errors.Annotate(err, "stopping LXD containers")
+	}
+	if err := revertAllLXDContainers(lxdToRevertByHost); err != nil {
+		return errors.Annotate(err, "reverting LXD containers")
+	}
+
+	// Start all not-running LXC containers back up. The agents must
+	// be stopped.
+	if err := startLXCContainers(lxcByHost); err != nil {
+		return errors.Annotate(err, "starting LXC containers")
+	}
+	if err := waitContainersReady(
+		"lxc", lxcByHost, containerNames,
+		5*time.Minute, // should be long enough for anyone
+	); err != nil {
+		return errors.Annotate(err, "waiting for reverted LXC containers to have addresses")
+	}
+	if err := stopContainerAgents(ctx, st, lxcByHost); err != nil {
+		return errors.Annotate(err, "stopping Juju agents in reverted LXC containers")
+	}
+
+	return nil
+}
+
+type containerMap map[string]*state.Machine
+
+type hostContainerMap map[*state.Machine]containerMap
+
+// getLXDContainersToRevert returns a map of the LXD containers to
+// revert. The outermost key is the host machine. The inner map is lxd
+// container name -> container state.Machine. (This lets us handle LXD
+// containers that have been migrated uniformly whether or not they've
+// been renamed.)
+func getAllLXDContainersToRevert(
+	ctx *cmd.Context,
+	lxcByHost map[*state.Machine][]*state.Machine,
+	lxdByHost map[*state.Machine]map[string]*lxdContainer,
+	containerNames map[*state.Machine]containerNames,
+) hostContainerMap {
+	lxdToRevertByHost := make(hostContainerMap)
+	for host, containers := range lxcByHost {
+		lxdContainers := lxdByHost[host]
+		toRevert := getLXDToRevertForHost(ctx, containers, lxdContainers, containerNames)
+		if len(toRevert) > 0 {
+			lxdToRevertByHost[host] = toRevert
+		}
+	}
+	return lxdToRevertByHost
+}
+
+// getLXDToRevertForHost returns a map of (lxd container name,
+// juju machine) for a specific host machine.
+func getLXDToRevertForHost(
+	ctx *cmd.Context,
+	lxcMachines []*state.Machine,
+	lxdContainers map[string]*lxdContainer,
+	containerNames map[*state.Machine]containerNames,
+) containerMap {
+	toRevert := make(map[string]*state.Machine)
+	for _, lxcMachine := range lxcMachines {
+		names := containerNames[lxcMachine]
+		if lxdContainers[names.oldName] != nil {
+			// migrated but not yet renamed
+			ctx.Infof(
+				"LXC container %q was migrated to LXD (%q)",
+				lxcMachine.Id(), names.oldName,
+			)
+			toRevert[names.oldName] = lxcMachine
+		} else if lxdContainers[names.newName] != nil {
+			// migrated and renamed
+			ctx.Infof(
+				"LXC container %q was migrated to LXD (%q)",
+				lxcMachine.Id(), names.newName,
+			)
+			toRevert[names.newName] = lxcMachine
+		} else {
+			ctx.Infof(
+				"LXC container %q hasn't been migrated to LXD (%q) - no revert needed",
+				lxcMachine.Id(), names.newName,
+			)
+		}
+	}
+	return toRevert
+}
+
+func stopLXDContainers(toRevertByHost hostContainerMap) error {
+	var group errgroup.Group
+	for host, containers := range toRevertByHost {
+		for lxdName := range containers {
+			logger.Debugf("stopping LXD container %q", lxdName)
+			host, lxdName := host, lxdName // copy for closure
+			group.Go(func() error {
+				return errors.Annotatef(
+					StopLXDContainer(lxdName, host),
+					"stopping LXD container %q",
+					lxdName,
+				)
+			})
+		}
+	}
+	return group.Wait()
+}
+
+// startLXCContainers will try to start all of the containers that
+// should be on each machine - this will already have been filtered by
+// the match expression. We don't bother checking for ones that are
+// already running - it's ok if they're already started, since
+// lxc-start still returns 0.
+func startLXCContainers(lxcByHost map[*state.Machine][]*state.Machine) error {
+	var group errgroup.Group
+	for host, containers := range lxcByHost {
+		for _, container := range containers {
+			logger.Debugf("starting reverted LXC container %q", container.Id())
+			host, container := host, container // copy for closure
+			group.Go(func() error {
+				return errors.Annotatef(
+					StartLXCContainer(container, host),
+					"starting LXC container %q",
+					container.Id(),
+				)
+			})
+		}
+	}
+	return group.Wait()
+}
+
+// revertLXDContainers converts the specified LXD containers back into
+// LXC containers by:
+// * moving the rootfs back into the LXC container,
+// * undoing the config change for the LXC container,
+// * deleting the LXD version of the container
+func revertAllLXDContainers(toRevertByHost hostContainerMap) error {
+	var group errgroup.Group
+	for host, containers := range toRevertByHost {
+		host, containers := host, containers // copy for closure
+		var containerNames []string
+		for name := range containers {
+			containerNames = append(containerNames, name)
+		}
+		group.Go(func() error {
+			return errors.Annotatef(
+				revertLXDForHost(host, containers),
+				"reverting LXD containers: %s", strings.Join(containerNames, ", "),
+			)
+		})
+	}
+	return group.Wait()
+}
+
+func revertLXDForHost(host *state.Machine, toRevert containerMap) error {
+	address, err := getMachineAddress(host)
+	if err != nil {
+		return errors.Annotatef(err, "getting address for machine %q", host.Id())
+	}
+
+	parts := []string{revertFunction}
+	for lxdName, lxcMachine := range toRevert {
+		instanceId, err := lxcMachine.InstanceId()
+		if err != nil {
+			return errors.Annotatef(err, "getting instance id for %q", lxcMachine.Id())
+		}
+		parts = append(parts, fmt.Sprintf(revertCall, lxdName, instanceId))
+	}
+	script := strings.Join(parts, "\n")
+	logger.Debugf("running revert script on %q:\n\n%s", host.Id(), script)
+	rc, err := runViaSSH(address, script, withSystemIdentity())
+	if err != nil {
+		return errors.Annotatef(err, "running revert script for %q", host.Id())
+	}
+	if rc != 0 {
+		return errors.Errorf("revert script exited %d", rc)
+	}
+	return nil
+}
+
+const (
+	revertFunction = `
+set -ex
+
+LXC_BASE=/var/lib/lxc
+LXD_BASE=/var/lib/lxd/containers
+
+function revert-lxd() {
+   source_lxd=$1
+   target_lxc=$2
+   echo reverting from $source_lxd to $target_lxc
+   # remove the migrated line from the config
+   sed '/^lxd.migrated=true$/d' -i $LXC_BASE/$target_lxc/config
+   # move the rootfs back
+   mv $LXD_BASE/$source_lxd/rootfs $LXC_BASE/$target_lxc/
+   # remove the container from lxd
+   lxc delete $source_lxd
+}
+`
+
+	revertCall = "revert-lxd %q %q"
+)


### PR DESCRIPTION
The reversion is done in-place:
* the rootfs is moved back to the LXC container,
* the LXC config change made in the migration is undone,
* and the LXD container is deleted (only affects config, since the data has been moved back).

This will be used if the upgrade needs to be aborted. The command accepts `--match` (like `migrate-lxc`) so that the containers can be reverted in stages to avoid interrupting the workload (if there are redundant units).