### PR TITLE
Make the maas provider conform to TagUpgrader

### DIFF
--- a/juju1/provider/maas/environ.go
+++ b/juju1/provider/maas/environ.go
@@ -2018,7 +2018,7 @@ func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]iface
 }
 
 // UpgradeTags is part of the TagUpgrader interface.
-func (environ *maasEnviron) UpgradeTags() error {
+func (environ *maasEnviron) UpgradeTags(string) error {
 	// We don't track machines in environments by tag in MAAS 1.9.
 	return nil
 }


### PR DESCRIPTION
It was missing a string parameter. This meant that importing would fail with the following error:
```
ERROR upgrading environment tags: "bootstack-staging-bos01-stable" (type=maas) environ doesn't support upgrading tags
```