### PR TITLE
Add missing juju/worker.v1 dependency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -102,8 +102,9 @@ gopkg.in/juju/charmstore.v5-unstable	git	fd1eef3002fc6b6daff5e97efab6f5056d22dcc
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	0f8ae7499c60de56e4cb4c5eabe2d504615a18ca	2017-05-15T22:48:47Z
+gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
+gopkg.in/macaroon-bakery.v0	git	7ab5879cabb9f9853941f0a0b3b7ff6ac4c4b292	2015-04-17T07:41:59Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
-gopkg.in/macaroon-bakery.v0	git	7ab5879cabb9f9853941f0a0b3b7ff6ac4c4b292	2017-09-21T02:40:54Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
 gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z


### PR DESCRIPTION
I already had this locally from building juju (on the 2.4 branch).

godeps wanted to include other packages because they're used by juju2 providers, but since the provider code isn't called from upgrade commands I left them out.

Fixes #66 
